### PR TITLE
Gestione durata completa delle slide

### DIFF
--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -51,8 +51,9 @@ export function buildTimeline(mods: Modifications): Segment[] {
       cursorSched += gap;
     } else if (gap > 0) cursorSched += gap;
 
-    timeline.push({ ...s, duration: s.duration + HOLD_EXTRA_MS / 1000 });
-    cursorSched += s.duration;
+    const dur = s.duration + HOLD_EXTRA_MS / 1000;
+    timeline.push({ ...s, duration: dur });
+    cursorSched += dur;
   });
 
   const outroText = normalizeQuotes(


### PR DESCRIPTION
## Summary
- calcola `dur` includendo `HOLD_EXTRA_MS` per ogni slide
- usa `dur` per push e avanzamento del cursore così i gap vengono conteggiati correttamente

## Testing
- `npm test` *(missing script: "test")*
- `npm run build`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b5db7c78688330b1d0c67fb079462e