### PR TITLE
feat: async ffmpeg rendering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,14 +80,16 @@ import { fetchAssets } from "./fetchAssets";
     console.log(`♻️  Riutilizzo ${found.length} segmenti da ${dir}`);
     segFiles = found;
   } else {
+    const tasks: Promise<void>[] = [];
     timeline.forEach((seg, idx) => {
       const out = join(paths.temp, `seg${idx}.mp4`);
+      let p: Promise<void>;
       if (seg.kind === "image")
-        renderImageSeg(seg, out, { fps, videoW, videoH, fontPath, logoPath });
+        p = renderImageSeg(seg, out, { fps, videoW, videoH, fontPath, logoPath });
       else if (seg.kind === "filler")
-        renderFillerSegment(seg, out, { fps, videoW, videoH, logoPath });
+        p = renderFillerSegment(seg, out, { fps, videoW, videoH, logoPath });
       else
-        renderOutroSegment(seg, out, {
+        p = renderOutroSegment(seg, out, {
           fps,
           videoW,
           videoH,
@@ -95,8 +97,9 @@ import { fetchAssets } from "./fetchAssets";
           logoPath,
         });
       segFiles.push(out);
-      console.log(`[OK ] Segmento creato: ${out}`);
+      tasks.push(p.then(() => console.log(`[OK ] Segmento creato: ${out}`)));
     });
+    await Promise.all(tasks);
   }
 
   // validazione/repair

--- a/src/renderers/filler.ts
+++ b/src/renderers/filler.ts
@@ -1,12 +1,12 @@
 import { existsSync } from "fs";
 import { FOOTER } from "../config";
-import { runFFmpeg } from "../ffmpeg/run";
+import { runFFmpegAsync } from "../ffmpeg/run";
 
 export function renderFillerSegment(
   seg: { duration: number },
   outPath: string,
   opts: { fps: number; videoW: number; videoH: number; logoPath?: string | null; }
-) {
+): Promise<void> {
   const { fps, videoW, videoH, logoPath } = opts;
   const args: string[] = ["-y","-f","lavfi","-t",`${seg.duration}`,"-r",`${fps}`,"-i",`color=c=black:s=${videoW}x${videoH}:r=${fps}`,
                           "-f","lavfi","-t",`${seg.duration}`,"-i","anullsrc=channel_layout=stereo:sample_rate=44100"];
@@ -22,5 +22,5 @@ export function renderFillerSegment(
             "-c:v","libx264","-pix_fmt","yuv420p","-preset","ultrafast",
             "-c:a","aac","-b:a","192k","-ar","44100","-ac","2","-shortest", outPath);
 
-  runFFmpeg(args, "FFmpeg SEG(filler)");
+  return runFFmpegAsync(args, "FFmpeg SEG(filler)");
 }

--- a/src/renderers/image.ts
+++ b/src/renderers/image.ts
@@ -1,13 +1,13 @@
 import { existsSync } from "fs";
 import { FOOTER, DEFAULT_TTS_VOL, SHADE } from "../config";
-import { runFFmpeg } from "../ffmpeg/run";
+import { runFFmpegAsync } from "../ffmpeg/run";
 import { shadeChain, buildFirstSlideTextChain, buildRevealTextChain_XFADE, zoomExprFullClip } from "../ffmpeg/filters";
 
 export function renderImageSeg(
   seg: { index?: number; duration: number; img?: string | null; tts?: string | null; text?: string; },
   outPath: string,
   opts: { fps: number; videoW: number; videoH: number; fontPath: string; logoPath?: string | null; }
-) {
+): Promise<void> {
   if (!seg.img) throw new Error(`Image file missing for slide ${seg.index}`);
 
   const { fps, videoW, videoH, fontPath, logoPath } = opts;
@@ -48,5 +48,5 @@ export function renderImageSeg(
             "-c:v","libx264","-pix_fmt","yuv420p","-preset","ultrafast",
             "-c:a","aac","-b:a","192k","-ar","44100","-ac","2","-shortest", outPath);
 
-  runFFmpeg(args, "FFmpeg SEG(image)");
+  return runFFmpegAsync(args, "FFmpeg SEG(image)");
 }

--- a/src/renderers/outro.ts
+++ b/src/renderers/outro.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
 import { FOOTER, SCALES } from "../config";
-import { runFFmpeg } from "../ffmpeg/run";
+import { runFFmpegAsync } from "../ffmpeg/run";
 import { escDrawText } from "../utils/text";
 import { deriveOrientation } from "../config";
 
@@ -8,7 +8,7 @@ export function renderOutroSegment(
   seg: { duration: number; text?: string },
   outPath: string,
   opts: { fps: number; videoW: number; videoH: number; fontPath: string; logoPath?: string | null; }
-) {
+): Promise<void> {
   const { fps, videoW, videoH, fontPath, logoPath } = opts;
   const text = seg.text || "";
 
@@ -57,5 +57,5 @@ export function renderOutroSegment(
     "-shortest", outPath
   );
 
-  runFFmpeg(args, "FFmpeg SEG(outro)");
+  return runFFmpegAsync(args, "FFmpeg SEG(outro)");
 }


### PR DESCRIPTION
## Summary
- add async FFmpeg runner returning a Promise
- renderers now return FFmpeg promises
- run segment rendering concurrently with Promise.all

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5dfd7fa2c8330ac1fae163f4363ef