### PR TITLE
Add basic utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "npm run build && node dist/main.js",
     "start:reuse": "npm run build && node dist/main.js --reuse-segs",
-    "start:reuse:dir": "npm run build && node dist/main.js --reuse-segs --segsDir src/temp"
+    "start:reuse:dir": "npm run build && node dist/main.js --reuse-segs --segsDir src/temp",
+    "test": "npm run build && node --test dist/utils/*.test.js"
   },
   "dependencies": {
     "node-fetch": "^3.3.2"

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { wrapParagraph, normalizeQuotes, escDrawText } from './text';
+
+test('wrapParagraph breaks text into lines respecting width', () => {
+  assert.deepStrictEqual(
+    wrapParagraph('uno due tre', 7),
+    ['uno due', 'tre']
+  );
+});
+
+test('wrapParagraph handles empty input', () => {
+  assert.deepStrictEqual(wrapParagraph('', 5), ['']);
+});
+
+test('normalizeQuotes replaces apostrophes with curly quotes', () => {
+  assert.strictEqual(normalizeQuotes("l'auto"), 'l’auto');
+});
+
+test('escDrawText doubles backslashes', () => {
+  assert.strictEqual(escDrawText('\\'), '\\\\');
+});
+
+test('escDrawText escapes colons', () => {
+  assert.strictEqual(escDrawText(':'), '\\:');
+});
+
+test("escDrawText escapes single quotes", () => {
+  assert.strictEqual(escDrawText("'"), "\\'");
+});

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSec, lineOffset } from './time';
+
+test('parseSec parses numbers from strings and falls back to default', () => {
+  assert.strictEqual(parseSec('1.5s'), 1.5);
+  assert.strictEqual(parseSec('3,5'), 3.5);
+  assert.strictEqual(parseSec('foo', 2), 2);
+  assert.strictEqual(parseSec(4), 4);
+});
+
+test('lineOffset applies stagger and clamps within segment duration', () => {
+  assert.strictEqual(lineOffset(2, 10, 2), 0.287);
+  assert.strictEqual(lineOffset(0, 1, 2), 0);
+});


### PR DESCRIPTION
## Summary
- add tests for utils text helpers
- add tests for time parsing helpers
- run test suite via `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f9bfb3e88330aa57b1678a1b52ad