### PR TITLE
Respect npm config flags for text transition

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,14 +2,23 @@ import type { TextTransition } from "./types";
 
 const ARGV = process.argv.slice(2);
 
+function readEnv(name: string) {
+  return (
+    process.env[name.toUpperCase()] ??
+    process.env[`npm_config_${name}`] ??
+    process.env[`npm_config_${name.toLowerCase()}`]
+  );
+}
+
 export function hasFlag(name: string) {
-  return ARGV.includes(`--${name}`) || process.env[name.toUpperCase()] === "1";
+  const env = readEnv(name);
+  return ARGV.includes(`--${name}`) || env === "1" || env === "true";
 }
 export function getOpt(name: string, def?: string) {
   const i = ARGV.indexOf(`--${name}`);
   if (i >= 0 && ARGV[i + 1] && !ARGV[i + 1].startsWith("--"))
     return ARGV[i + 1].trim();
-  const env = process.env[name.toUpperCase()];
+  const env = readEnv(name);
   return env ? env.trim() : def;
 }
 


### PR DESCRIPTION
## Summary
- ensure CLI picks up `npm_config_*` env vars so `npm start --textTransition` works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70b0797488330950cfa561d5f682b