### PR TITLE
Respect npm config flags for text transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node dist/main.js",
     "start:reuse": "npm run build && node dist/main.js --reuse-segs",
     "start:reuse:dir": "npm run build && node dist/main.js --reuse-segs --segsDir src/temp",
-    "test": "npm run build && node --test dist/utils"
+      "test": "npm run build && node --test dist/utils/*.test.js"
   },
   "dependencies": {
     "node-fetch": "^3.3.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,15 +2,41 @@ import type { TextTransition } from "./types";
 
 const ARGV = process.argv.slice(2);
 
+function readEnv(name: string) {
+  return (
+    process.env[name.toUpperCase()] ??
+    process.env[`npm_config_${name}`] ??
+    process.env[`npm_config_${name.toLowerCase()}`]
+  );
+}
+
+function readFromNpmArgv(name: string) {
+  try {
+    const raw = process.env.npm_config_argv;
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as { cooked?: string[]; original?: string[] };
+    const arr = parsed?.original ?? parsed?.cooked ?? [];
+    const idx = arr.indexOf(`--${name}`);
+    if (idx >= 0 && arr[idx + 1] && !arr[idx + 1].startsWith("--")) {
+      return arr[idx + 1].trim();
+    }
+  } catch {
+    // ignore
+  }
+}
+
 export function hasFlag(name: string) {
-  return ARGV.includes(`--${name}`) || process.env[name.toUpperCase()] === "1";
+  const env = readEnv(name);
+  return ARGV.includes(`--${name}`) || env === "1" || env === "true";
 }
 export function getOpt(name: string, def?: string) {
   const i = ARGV.indexOf(`--${name}`);
   if (i >= 0 && ARGV[i + 1] && !ARGV[i + 1].startsWith("--"))
     return ARGV[i + 1].trim();
-  const env = process.env[name.toUpperCase()];
-  return env ? env.trim() : def;
+  const env = readEnv(name);
+  if (env && env !== "true" && env !== "1") return env.trim();
+  const npmArgvVal = readFromNpmArgv(name);
+  return npmArgvVal ?? def;
 }
 
 export const REUSE_SEGS = hasFlag("reuse-segs") || hasFlag("reuseSegs") || hasFlag("reuse");

--- a/src/utils/cli.test.ts
+++ b/src/utils/cli.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Ensure options can be read from npm_config_argv when env value is boolean
+
+test('getOpt reads npm argv config value', async () => {
+  process.env.npm_config_texttransition = 'true';
+  process.env.npm_config_argv = JSON.stringify({
+    original: ['--textTransition', 'wipeleft'],
+  });
+  const { getOpt } = await import('../cli');
+  assert.equal(getOpt('textTransition', 'wipeup'), 'wipeleft');
+});


### PR DESCRIPTION
## Summary
- read `npm_config_argv` to recover option values so `npm start --textTransition` works
- run tests against all util test files and cover npm argv fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70b0797488330950cfa561d5f682b