### PR TITLE
Tune template text wrapping

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -37,8 +37,8 @@ export const SCALES = {
 
 /** Target “wrapping” di partenza (caratteri) — verrà adattato in autosize */
 export const WRAP_TARGET = {
-  landscape: { FIRST: 26, OTHER: 35 },
-  portrait:  { FIRST: 18, OTHER: 22 },
+  landscape: { FIRST: 40, OTHER: 30 },
+  portrait:  { FIRST: 24, OTHER: 20 },
 };
 
 export const STAGGER = { base: 0.10, growth: 0.10, jitter: 0.015 };

--- a/src/ffmpeg/filters.ts
+++ b/src/ffmpeg/filters.ts
@@ -74,8 +74,7 @@ export function buildFirstSlideTextChain(
 
   const baseCols = WRAP_TARGET[orientation].FIRST;
   const targetOverride = transition === "wiperight"
-    ? Math.max(1, Math.round(baseCols * 0.8))
-
+    ? 35
     : undefined;
 
   const auto = autosizeAndWrap(txt, {
@@ -156,8 +155,7 @@ export function buildRevealTextChain_XFADE(
   const orientation: Orientation = deriveOrientation(videoW, videoH);
   const baseCols = WRAP_TARGET[orientation].OTHER;
   const targetOverride = transition === "wiperight"
-    ? Math.max(1, Math.round(baseCols * 0.8))
-
+    ? 30
     : undefined;
 
   const auto = autosizeAndWrap(txt, {

--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -9,6 +9,14 @@ test('wrapParagraph breaks text into lines respecting width', () => {
   );
 });
 
+test('wrapParagraph wraps at about 30 chars', () => {
+  const txt = 'Una serie di scosse, a partire da domenica';
+  assert.deepStrictEqual(
+    wrapParagraph(txt, 30),
+    ['Una serie di scosse, a partire', 'da domenica']
+  );
+});
+
 test('wrapParagraph handles empty input', () => {
   assert.deepStrictEqual(wrapParagraph('', 5), ['']);
 });


### PR DESCRIPTION
## Summary
- Increase default wrap limits so the first slide can hold more characters than the others
- Force ~30 chars per line on template2 with a bigger allowance for its first slide
- Add regression test for 30-character wrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8474eb368833082244a4f3dbbae2d