### PR TITLE
Avoid font resizing for vertical slides

### DIFF
--- a/src/utils/autosize.ts
+++ b/src/utils/autosize.ts
@@ -1,5 +1,5 @@
 // src/utils/autosize.ts
-import { FOOTER, SCALES, TEXT, WRAP_TARGET, deriveOrientation } from "../config";
+import { FOOTER, SCALES, TEXT, WRAP_TARGET } from "../config";
 
 export type Orientation = "landscape" | "portrait";
 
@@ -53,48 +53,67 @@ function greedyWrapByCols(words: string[], cols: number): string[] {
   return lines;
 }
 
+/** numero massimo di colonne in slide verticale in base alla larghezza disponibile */
+function maxColsForPortrait(videoW: number, fontSize: number, padPx: number): number {
+  const margin = Math.round(videoW * TEXT.LEFT_MARGIN_P);
+  const maxWidth = videoW - margin * 2;
+  return Math.floor((maxWidth - padPx * 2) / (fontSize * TEXT.CHAR_WIDTH_K));
+}
+
 /** calcola fontSize/lineH/y0/xExpr coerenti e restituisce righe “bilanciate” */
 export function autosizeAndWrap(text: string, opts: AutoOpts): AutoSizeResult {
   const { videoW, videoH, orientation, isFirstSlide, align, targetColsOverride } = opts;
 
-  // 1) tokenizza e wrap greedy sui target di caratteri
+  // 1) tokenizza
   const words = tokenize(text);
-  const defaultCols = isFirstSlide
-    ? WRAP_TARGET[orientation].FIRST
-    : WRAP_TARGET[orientation].OTHER;
-  const targetCols = targetColsOverride ?? defaultCols;
+  let lines: string[] = [];
+  if (orientation === "landscape") {
+    const defaultCols = isFirstSlide
+      ? WRAP_TARGET[orientation].FIRST
+      : WRAP_TARGET[orientation].OTHER;
+    const targetCols = targetColsOverride ?? defaultCols;
+    lines = greedyWrapByCols(words, targetCols);
+  }
 
-  const lines = greedyWrapByCols(words, targetCols);
-
-
-  // 3) area verticale disponibile
+  // 2) area verticale disponibile
   const topMarginPx = Math.round(videoH * TEXT.TOP_MARGIN_P[orientation]);
   const bottomLimit = videoH - (FOOTER.MARGIN_BOTTOM + FOOTER.LOGO_HEIGHT + FOOTER.GAP) - 16;
   const available = Math.max(40, bottomLimit - topMarginPx);
 
-  // 4) fontSize base → clamp → ricava lineH e forza a stare tutto in altezza disponibile
+  // 3) fontSize base → clamp → ricava lineH
   const baseScale = isFirstSlide ? SCALES[orientation].FIRST : SCALES[orientation].OTHER;
   let fontSize = Math.round(videoH * baseScale);
   fontSize = Math.max(TEXT.MIN_SIZE, Math.min(TEXT.MAX_SIZE, fontSize));
 
   let lineH = Math.max(1, Math.round(fontSize * TEXT.LINE_HEIGHT));
+
+  // 4) calcolo margini e padding
+  const margin = Math.round(videoW * TEXT.LEFT_MARGIN_P);
+  const maxWidth = videoW - margin * 2;
+  let padPx = Math.max(4, Math.round(fontSize * TEXT.BOX_PAD_FACTOR));
+
+  if (orientation === "portrait") {
+    const maxCols = maxColsForPortrait(videoW, fontSize, padPx);
+    lines = greedyWrapByCols(words, maxCols);
+    const maxLines = Math.floor(available / lineH);
+    if (lines.length > maxLines) lines = lines.slice(0, maxLines);
+  }
+
   let blockH = lines.length * lineH;
 
-  if (blockH > available) {
+  if (orientation === "landscape" && blockH > available) {
     // ricalcola font per far stare tutte le righe nello spazio
     fontSize = Math.floor(available / (lines.length * TEXT.LINE_HEIGHT));
     fontSize = Math.max(TEXT.MIN_SIZE, Math.min(TEXT.MAX_SIZE, fontSize));
     lineH = Math.max(1, Math.round(fontSize * TEXT.LINE_HEIGHT));
+    padPx = Math.max(4, Math.round(fontSize * TEXT.BOX_PAD_FACTOR));
     blockH = lines.length * lineH;
   }
 
-  // 5) verifica larghezza massima e ridimensiona se necessario
-  const margin = Math.round(videoW * TEXT.LEFT_MARGIN_P);
-  const maxWidth = videoW - margin * 2;
-  let padPx = Math.max(4, Math.round(fontSize * TEXT.BOX_PAD_FACTOR));
+  // 5) verifica larghezza massima e ridimensiona se necessario (solo landscape)
   let maxLineW =
     Math.max(0, ...lines.map((l) => l.length)) * fontSize * TEXT.CHAR_WIDTH_K + padPx * 2;
-  if (maxLineW > maxWidth) {
+  if (orientation === "landscape" && maxLineW > maxWidth) {
     const scale = maxWidth / maxLineW;
     fontSize = Math.max(TEXT.MIN_SIZE, Math.floor(fontSize * scale));
     lineH = Math.max(1, Math.round(fontSize * TEXT.LINE_HEIGHT));


### PR DESCRIPTION
## Summary
- avoid auto-resizing fonts when rendering portrait slides
- add overflow checks for height and width in vertical slides
- prevent errors by dynamically wrapping portrait text based on width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85af5bdb88330a876ba01a98f0dcb