### PR TITLE
Ensure consistent line spacing in text segments

### DIFF
--- a/src/ffmpeg/filters.test.ts
+++ b/src/ffmpeg/filters.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildFirstSlideTextChain, buildRevealTextChain_XFADE } from "./filters";
+
+const opts = {
+  segDur: 5,
+  fontfile: "dummy.ttf",
+  videoW: 1920,
+  videoH: 1080,
+  fps: 30
+};
+
+test("text chains use ascent/descent for consistent spacing", () => {
+  const chainFirst = buildFirstSlideTextChain(
+    "prima riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
+  );
+  assert.ok(chainFirst.includes("h-ascent-descent-1"));
+  assert.ok(!chainFirst.includes("text_h"));
+
+  const chainOther = buildRevealTextChain_XFADE(
+    "seconda riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
+  );
+  assert.ok(chainOther.includes("h-ascent-descent-1"));
+  assert.ok(!chainOther.includes("text_h"));
+});

--- a/src/ffmpeg/filters.ts
+++ b/src/ffmpeg/filters.ts
@@ -119,8 +119,8 @@ export function buildFirstSlideTextChain(
 
     parts.push(`color=c=black@0.0:s=${videoW}x${CANV_H}:r=${fps}:d=${segDur},format=rgba,setsar=1[S${i}_canvas]`);
     // box “doppio” per bordo pieno + anti-alias
-    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-text_h-1+${EXTRA}:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
-    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-text_h-1:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
+    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-ascent-descent-1+${EXTRA}:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
+    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
 
     // alpha wipe con direzione configurabile
     parts.push(`[S${i}_rgba]split=2[S${i}_rgb][S${i}_forA]`);
@@ -197,7 +197,7 @@ export function buildRevealTextChain_XFADE(
 
     // canvas “a riga” di altezza esatta = lineH ⇒ spaziatura identica
     parts.push(`color=c=black@0.0:s=${videoW}x${auto.lineH}:r=${fps}:d=${segDur},format=rgba,setsar=1[L${i}_canvas]`);
-    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-text_h-1:text='${safe}'[L${i}_rgba]`);
+    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1:text='${safe}'[L${i}_rgba]`);
 
     // alpha XFADE (wipeup/wipedown/wipeleft/wiperight)
     parts.push(`[L${i}_rgba]split=2[L${i}_rgb][L${i}_forA]`);


### PR DESCRIPTION
## Summary
- Use font ascent/descent metrics in drawtext expressions to ensure uniform line spacing across lines
- Add unit tests confirming ascent/descent-based positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b860c14198833089bbcebb9604906a