### PR TITLE
Remove extra text margin and align lines with descent

### DIFF
--- a/src/ffmpeg/filters.test.ts
+++ b/src/ffmpeg/filters.test.ts
@@ -10,16 +10,16 @@ const opts = {
   fps: 30
 };
 
-test("text chains use ascent/descent for consistent spacing", () => {
+test("text chains keep consistent spacing using descent", () => {
   const chainFirst = buildFirstSlideTextChain(
     "prima riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
   );
-  assert.ok(chainFirst.includes("h-ascent-descent-1"));
+  assert.ok(chainFirst.includes("h-descent"));
   assert.ok(!chainFirst.includes("text_h"));
 
   const chainOther = buildRevealTextChain_XFADE(
     "seconda riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
   );
-  assert.ok(chainOther.includes("h-ascent-descent-1"));
+  assert.ok(chainOther.includes("h-descent"));
   assert.ok(!chainOther.includes("text_h"));
 });

--- a/src/ffmpeg/filters.ts
+++ b/src/ffmpeg/filters.ts
@@ -89,8 +89,7 @@ export function buildFirstSlideTextChain(
 
   if (!auto.lines.length || (auto.lines.length === 1 && auto.lines[0] === "")) return `[pre]null[v]`;
 
-  const EXTRA  = Math.max(6, Math.round(videoH * 0.06));
-  const CANV_H = auto.lineH + EXTRA;
+  const CANV_H = auto.lineH;
 
   const parts: string[] = [];
   let inLbl = "pre";
@@ -119,8 +118,8 @@ export function buildFirstSlideTextChain(
 
     parts.push(`color=c=black@0.0:s=${videoW}x${CANV_H}:r=${fps}:d=${segDur},format=rgba,setsar=1[S${i}_canvas]`);
     // box “doppio” per bordo pieno + anti-alias
-    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-ascent-descent-1+${EXTRA}:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
-    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
+    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-descent:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
+    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-descent:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
 
     // alpha wipe con direzione configurabile
     parts.push(`[S${i}_rgba]split=2[S${i}_rgb][S${i}_forA]`);
@@ -190,17 +189,15 @@ export function buildRevealTextChain_XFADE(
     inLbl = "bar_out";
   }
 
-  const EXTRA = Math.max(6, Math.round(videoH * 0.06));
-
   for (let i = 0; i < auto.lines.length; i++) {
     const safe   = escDrawText(auto.lines[i]);
     const offset = lineOffset(i, segDur, 0.6);
     const lineY  = auto.y0 + i * auto.lineH;
 
-    // canvas “a riga” con margine extra per evitare il taglio delle linee
-    const canvH = auto.lineH + EXTRA;
+    // canvas “a riga” senza margine aggiuntivo
+    const canvH = auto.lineH;
     parts.push(`color=c=black@0.0:s=${videoW}x${canvH}:r=${fps}:d=${segDur},format=rgba,setsar=1[L${i}_canvas]`);
-    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1+${EXTRA}:text='${safe}'[L${i}_rgba]`);
+    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-descent:text='${safe}'[L${i}_rgba]`);
 
     // alpha XFADE (wipeup/wipedown/wipeleft/wiperight)
     parts.push(`[L${i}_rgba]split=2[L${i}_rgb][L${i}_forA]`);


### PR DESCRIPTION
## Summary
- remove per-line text margin from ffmpeg filters
- align text lines using `descent` for consistent spacing
- update tests for new baseline expression

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b889974af483309b5780c6a60824fc