### PR TITLE
Restore text baseline margin for consistent spacing

### DIFF
--- a/src/ffmpeg/filters.test.ts
+++ b/src/ffmpeg/filters.test.ts
@@ -10,16 +10,16 @@ const opts = {
   fps: 30
 };
 
-test("text chains keep consistent spacing using descent", () => {
+test("text chains use ascent/descent for consistent spacing", () => {
   const chainFirst = buildFirstSlideTextChain(
     "prima riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
   );
-  assert.ok(chainFirst.includes("h-descent"));
+  assert.ok(chainFirst.includes("h-ascent-descent-1"));
   assert.ok(!chainFirst.includes("text_h"));
 
   const chainOther = buildRevealTextChain_XFADE(
     "seconda riga", opts.segDur, opts.fontfile, opts.videoW, opts.videoH, opts.fps
   );
-  assert.ok(chainOther.includes("h-descent"));
+  assert.ok(chainOther.includes("h-ascent-descent-1"));
   assert.ok(!chainOther.includes("text_h"));
 });

--- a/src/ffmpeg/filters.ts
+++ b/src/ffmpeg/filters.ts
@@ -89,7 +89,8 @@ export function buildFirstSlideTextChain(
 
   if (!auto.lines.length || (auto.lines.length === 1 && auto.lines[0] === "")) return `[pre]null[v]`;
 
-  const CANV_H = auto.lineH;
+  const EXTRA  = Math.max(6, Math.round(videoH * 0.06));
+  const CANV_H = auto.lineH + EXTRA;
 
   const parts: string[] = [];
   let inLbl = "pre";
@@ -118,8 +119,8 @@ export function buildFirstSlideTextChain(
 
     parts.push(`color=c=black@0.0:s=${videoW}x${CANV_H}:r=${fps}:d=${segDur},format=rgba,setsar=1[S${i}_canvas]`);
     // box “doppio” per bordo pieno + anti-alias
-    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-descent:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
-    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-descent:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
+    parts.push(`[S${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}@0:x=${auto.xExpr}:y=h-ascent-descent-1+${EXTRA}:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_big]`);
+    parts.push(`[S${i}_big]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1:text='${safe}':box=1:boxcolor=white@1.0:boxborderw=${auto.padPx}[S${i}_rgba]`);
 
     // alpha wipe con direzione configurabile
     parts.push(`[S${i}_rgba]split=2[S${i}_rgb][S${i}_forA]`);
@@ -189,15 +190,17 @@ export function buildRevealTextChain_XFADE(
     inLbl = "bar_out";
   }
 
+  const EXTRA = Math.max(6, Math.round(videoH * 0.06));
+
   for (let i = 0; i < auto.lines.length; i++) {
     const safe   = escDrawText(auto.lines[i]);
     const offset = lineOffset(i, segDur, 0.6);
     const lineY  = auto.y0 + i * auto.lineH;
 
-    // canvas “a riga” senza margine aggiuntivo
-    const canvH = auto.lineH;
+    // canvas “a riga” con margine extra per evitare il taglio delle linee
+    const canvH = auto.lineH + EXTRA;
     parts.push(`color=c=black@0.0:s=${videoW}x${canvH}:r=${fps}:d=${segDur},format=rgba,setsar=1[L${i}_canvas]`);
-    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-descent:text='${safe}'[L${i}_rgba]`);
+    parts.push(`[L${i}_canvas]drawtext=fontfile='${fontfile}':fontsize=${auto.fontSize}:fontcolor=${color}:x=${auto.xExpr}:y=h-ascent-descent-1+${EXTRA}:text='${safe}'[L${i}_rgba]`);
 
     // alpha XFADE (wipeup/wipedown/wipeleft/wiperight)
     parts.push(`[L${i}_rgba]split=2[L${i}_rgb][L${i}_forA]`);


### PR DESCRIPTION
## Summary
- restore extra canvas margin and ascent/descent baseline in text filters to prevent cropping
- update tests to reflect ascent/descent usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89f17eca08330ba5ae821646f5cae