### PR TITLE
Fix landscape logo placement for template2

### DIFF
--- a/src/renderers/image.template2.test.ts
+++ b/src/renderers/image.template2.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, unlinkSync } from "fs";
+import { FOOTER } from "../config";
+
+// Ensure template2 landscape places logo below text
+test("template2 landscape logo below text", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  writeFileSync("dummy_img.png", "");
+  writeFileSync("dummy_logo.png", "");
+  const { renderImageSeg } = require("./image");
+  renderImageSeg(
+    { duration: 1, img: "dummy_img.png", text: "ciao" },
+    "out.mp4",
+    {
+      fps: 30,
+      videoW: 1920,
+      videoH: 1080,
+      fontPath: "font.ttf",
+      logoPath: "dummy_logo.png",
+      textTransition: "wiperight",
+      shadeColor: "red",
+      fillColor: "red",
+      logoPosition: "top-left",
+    }
+  );
+  unlinkSync("dummy_img.png");
+  unlinkSync("dummy_logo.png");
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fchain = captured![idx + 1];
+  assert.ok(fchain.includes(`:y=H-h-${FOOTER.MARGIN_BOTTOM}`));
+});
+

--- a/src/renderers/image.ts
+++ b/src/renderers/image.ts
@@ -120,9 +120,9 @@ export function renderImageSeg(
         });
         const barW = Math.max(4, Math.round(auto.fontSize * 0.5));
         const barX = Math.max(0, margin - barW - auto.padPx);
-        const logoY = Math.round(auto.y0 + auto.lines.length * auto.lineH + FOOTER.GAP);
         const logoXExpr = `${barX - FOOTER.GAP}-w`;
-        footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${logoXExpr}:y=${logoY}[pre]`;
+        const logoYExpr = `H-h-${FOOTER.MARGIN_BOTTOM}`;
+        footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${logoXExpr}:y=${logoYExpr}[pre]`;
       } else {
         const logoY = FOOTER.MARGIN_BOTTOM + FOOTER.GAP;
         footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${margin}:y=${logoY}[pre]`;


### PR DESCRIPTION
## Summary
- Place top-left logos at the bottom of the bar in template2 landscape videos
- Add regression test to ensure logo sits below the text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a785ff148330b094f4dd97082786