### PR TITLE
Place tmp2 landscape logo at top-left

### DIFF
--- a/src/renderers/image.template2.test.ts
+++ b/src/renderers/image.template2.test.ts
@@ -1,11 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { writeFileSync, unlinkSync } from "fs";
-import { FOOTER, TEXT } from "../config";
+import { TEXT } from "../config";
 
 
-// Ensure template2 landscape places logo below text
-test("template2 landscape logo below text", (t) => {
+// Ensure template2 landscape places logo at top-left aligned with bar
+test("template2 landscape logo top-left", (t) => {
   let captured: string[] | undefined;
   const runMod = require("../ffmpeg/run");
   t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
@@ -39,11 +39,8 @@ test("template2 landscape logo below text", (t) => {
   assert.notEqual(idx, -1);
   const fchain = captured![idx + 1];
   const margin = Math.round(1920 * TEXT.LEFT_MARGIN_P);
-  assert.ok(
-    fchain.includes(
-      `overlay=x=${margin}:y=H-h-${FOOTER.MARGIN_BOTTOM}`
-    )
-  );
+  const top = Math.round(1080 * TEXT.TOP_MARGIN_P.landscape);
+  assert.ok(fchain.includes(`overlay=x=${margin}:y=${top}`));
 
 });
 

--- a/src/renderers/image.ts
+++ b/src/renderers/image.ts
@@ -125,9 +125,13 @@ export function renderImageSeg(
       const margin = Math.round(videoW * TEXT.LEFT_MARGIN_P) + extraLeft;
       if (transition === "wiperight") {
         const logoX = margin;
-        const logoYExpr = `H-h-${FOOTER.MARGIN_BOTTOM}`;
-        footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${logoX}:y=${logoYExpr}[pre]`;
-
+        if (orientation === "landscape") {
+          const topMargin = Math.round(videoH * TEXT.TOP_MARGIN_P[orientation]);
+          footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${logoX}:y=${topMargin}[pre]`;
+        } else {
+          const logoYExpr = `H-h-${FOOTER.MARGIN_BOTTOM}`;
+          footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${logoX}:y=${logoYExpr}[pre]`;
+        }
       } else {
         const logoY = FOOTER.MARGIN_BOTTOM + FOOTER.GAP;
         footer += `;[3:v]scale=-1:${FOOTER.LOGO_HEIGHT},format=rgba[lg];[pre1][lg]overlay=x=${margin}:y=${logoY}[pre]`;


### PR DESCRIPTION
## Summary
- Position tmp2's logo at the top-left with top and left margins when in landscape orientation
- Update template2 image test for new top-left placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94fc523d88330b5471b977ab4f3ac