### PR TITLE
Use Creatomate template for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ Assicurarsi che `ffmpeg` funzioni lanciando `ffmpeg -version` dal terminale.
 ```bash
 npm start               # build + esecuzione completa
 npm start -- --reuse-segs     # riusa segmenti esistenti in src/temp
-npm start -- --template tmp2  # usa il template alternativo
 npm start -- --barColor blue  # imposta il colore della barretta del testo
 
 ```
+
+Il file `template/creatomate_template_news_horizontal.json` viene utilizzato
+automaticamente per determinare colori, animazioni e altre impostazioni del
+video, senza dover più passare l'opzione `--template` da riga di comando.
 I flag aggiuntivi sono descritti in `src/cli.ts`.
 
 Il risultato finale viene salvato in `download/final.mp4`.

--- a/src/template.ts
+++ b/src/template.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { projectRoot } from "./paths";
 import { FullData } from "./types";
 import { getOpt, hasFlag } from "./cli";
+import { generateFilteredTemplate } from "./tools/genTemplate";
 
 /**
  * Carica il file di template JSON (versione orizzontale o verticale) e lo
@@ -11,7 +12,8 @@ import { getOpt, hasFlag } from "./cli";
 export function loadTemplate(): FullData {
   const fmtOpt = getOpt("format");
   const isVertical = fmtOpt === "vertical" || hasFlag("vertical");
-  const file = isVertical ? "risposta_vertical.json" : "risposta_horizontal.json";
+  if (!isVertical) generateFilteredTemplate();
+  const file = isVertical ? "risposta_vertical.json" : "risposta_horizontal_filtered.json";
   const tpl = join(projectRoot, "template", file);
   const raw = readFileSync(tpl, "utf-8");
   return JSON.parse(raw) as FullData;


### PR DESCRIPTION
## Summary
- Derive rendering settings directly from `creatomate_template_news_horizontal.json`, removing the need for the `--template` CLI flag.
- Automatically generate and load `risposta_horizontal_filtered.json` from the Creatomate data when fetching the template.
- Document the new automatic template usage in the README.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95ff6c5cc8330b52d81369cf640c1