### PR TITLE
Add TTS audio and full-size images in rendered slides

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,7 @@ import { sendFinalVideo } from "./share";
           videoW,
           videoH,
           fonts,
+          ttsPath: seg.tts || undefined,
 
         });
       }

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -48,4 +48,10 @@ export function wrapParagraph(text: string, width = 30): string[] {
 export function normalizeQuotes(s: string): string { return String(s).replace(/'/g, "’"); }
 
 /** Escapa stringhe per l'uso nel filtro `drawtext` di FFmpeg. */
-export function escDrawText(s: string): string { return s.replace(/\\/g, "\\\\").replace(/:/g, "\\:").replace(/'/g, "\\'"); }
+export function escDrawText(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/:/g, "\\:")
+    .replace(/'/g, "\\'")
+    .replace(/,/g, "\\,");
+}


### PR DESCRIPTION
## Summary
- Support optional TTS audio for slides and pass audio paths from the main flow
- Escape commas in drawtext strings and scale images to cover the canvas when no size is provided

## Testing
- `npm test`
- `npm start` *(fails: request to remote assets failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b981e9ee1483308461d4fa4ac2e0c4