### PR TITLE
Escape commas in ffmpegSafePath

### DIFF
--- a/src/utils/ffmpeg.test.ts
+++ b/src/utils/ffmpeg.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { ffmpegSafePath } from "./ffmpeg";
 
-test("ffmpegSafePath escapes drive colon, spaces and brackets", () => {
+test("ffmpegSafePath escapes drive colon, spaces, brackets and commas", () => {
   const out = ffmpegSafePath("C:\\Fonts\\My Font[wdth,wght].ttf");
-  assert.equal(out, "C\\:/Fonts/My\\ Font\\[wdth,wght\\].ttf");
+  assert.equal(out, "C\\:/Fonts/My\\ Font\\[wdth\\,wght\\].ttf");
 });

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -4,6 +4,7 @@ export function ffmpegSafePath(p: string): string {
     .replace(/ /g, "\\ ")
     .replace(/'/g, "\\'")
     .replace(/:/g, "\\:")
+    .replace(/,/g, "\\,")
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }


### PR DESCRIPTION
## Summary
- escape commas in ffmpegSafePath to handle variable font filenames
- update ffmpegSafePath tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b987308250833083474e03947740a8