### PR TITLE
Handle special characters in drawtext font paths

### DIFF
--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -51,7 +51,7 @@ test("renderTemplateSlide overlays image and text", (t) => {
   assert.ok(fc.includes("overlay"));
   assert.ok(fc.includes("drawtext"));
   assert.ok(fc.includes("scale=192:216"));
-  assert.ok(fc.includes("fontfile=C\\:/fonts/font.ttf"));
+  assert.ok(fc.includes("fontfile='C\\:/fonts/font.ttf'"));
   assert.ok(fc.includes("overlay=x=864:y=432"));
 
 });

--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -83,7 +83,7 @@ export function renderTemplateElement(
     const color = normalizeColor(el.fill_color || "white");
     const fontsize = dimToPx(el.height, videoH) ?? 48;
     const font = ffmpegSafePath(pickFont(el.font_family));
-    filter = `[0:v]drawtext=fontfile=${font}:text='${text}':x=${finalX}:y=${finalY}:fontsize=${fontsize}:fontcolor=${color}[v]`;
+    filter = `[0:v]drawtext=fontfile='${font}':text='${text}':x=${finalX}:y=${finalY}:fontsize=${fontsize}:fontcolor=${color}[v]`;
   } else if (el.type === "image") {
     if (!el.file) throw new Error("image element missing file path");
     args.push("-loop", "1", "-t", `${duration}`, "-i", el.file);
@@ -156,7 +156,7 @@ export function renderTemplateSlide(
       const color = normalizeColor(el.fill_color || "white");
       const fontsize = dimToPx(el.height, videoH) ?? 48;
       const font = ffmpegSafePath(pickFont(el.font_family));
-      filter += `${cur}drawtext=fontfile=${font}:text='${text}':x=${fx}:y=${fy}:fontsize=${fontsize}:fontcolor=${color}${outLbl};`;
+      filter += `${cur}drawtext=fontfile='${font}':text='${text}':x=${fx}:y=${fy}:fontsize=${fontsize}:fontcolor=${color}${outLbl};`;
     } else if (el.type === "image") {
       if (!el.file) return; // skip if missing file
       args.push("-loop", "1", "-t", `${duration}`, "-i", el.file);


### PR DESCRIPTION
## Summary
- Quote font file paths in drawtext filters so ffmpeg accepts spaces, brackets and commas
- Update template slide tests for quoted font paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98b07780c8330b1e10d64b58c5864