### PR TITLE
Fix sidechaincompress labeling in concat filter chain

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -42,12 +42,14 @@ export function concatAndFinalizeDemuxer({
   const baseAudio = haveAudio
     ? `[0:a:0]aformat=channel_layouts=stereo:sample_rates=44100,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[${baseLabel}]`
     : `anullsrc=channel_layout=stereo:sample_rate=44100,asetpts=PTS-STARTPTS[${baseLabel}]`;
+
   const audioChain = haveBg
     ? [
         baseAudio,
-        `[1:a:0]aformat=channel_layouts=stereo:sample_rates=44100,volume=${bgVolume}[bg]`,
-        `[bg][${baseLabel}]sidechaincompress=threshold=${DUCK.threshold}:ratio=${DUCK.ratio}:attack=${DUCK.attack}:release=${DUCK.release}:makeup=${DUCK.makeup}[bgduck]`,
-        `[${baseLabel}][bgduck]amix=inputs=2:normalize=0:duration=longest:dropout_transition=0[mix]`
+        `[${baseLabel}]asplit=2[mainsc][mainmix]`,
+        `[1:a:0][mainsc]sidechaincompress=threshold=${DUCK.threshold}:ratio=${DUCK.ratio}:attack=${DUCK.attack}:release=${DUCK.release}:makeup=${DUCK.makeup}[bgduck]`,
+        `[bgduck]aformat=channel_layouts=stereo:sample_rates=44100,volume=${bgVolume}[bg]`,
+        `[mainmix][bg]amix=inputs=2:normalize=0:duration=longest:dropout_transition=0[mix]`
       ].join(";")
     : `${baseAudio};[${baseLabel}]anull[mix]`;
 


### PR DESCRIPTION
## Summary
- Fix `sidechaincompress` filter chaining by using `asplit` on main audio and connecting the background stream directly
- Post-process ducked background with `aformat` and `volume` before mixing

## Testing
- `npm test`
- `node -e "require('./dist/concat.js').concatAndFinalizeDemuxer({segments:['./seg0.mp4','./seg1.mp4'],bgAudioPath:'./download/bg.mp3',outPath:'./final_fixed2.mp4',concatTxtPath:'./segs.txt',fps:30,bgVolume:0.15});"`

------
https://chatgpt.com/codex/tasks/task_e_68b9a0cee5808330b51296e8047eb56e