### PR TITLE
fix: preserve audio sync during concat

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -40,8 +40,8 @@ export function concatAndFinalizeDemuxer({
   const haveAudio = probe?.streams?.some((s: any) => s.codec_type === "audio");
   const baseLabel = "mainaud"; // etichetta neutra per l'audio principale
   const baseAudio = haveAudio
-    ? `[0:a:0]aformat=channel_layouts=stereo:sample_rates=44100,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[${baseLabel}]`
-    : `anullsrc=channel_layout=stereo:sample_rate=44100,asetpts=PTS-STARTPTS[${baseLabel}]`;
+    ? `[0:a:0]aformat=channel_layouts=stereo:sample_rates=44100[${baseLabel}]`
+    : `anullsrc=channel_layout=stereo:sample_rate=44100[${baseLabel}]`;
 
   const audioChain = haveBg
     ? [


### PR DESCRIPTION
## Summary
- ensure final concat passes through segment audio without resampling or timestamp resets
- keep ducking mix but add background only after segments are joined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a54de42c833082d9e13566f1e5ad