### PR TITLE
Handle trailing gaps with filler segments

### DIFF
--- a/docs/funzioni.md
+++ b/docs/funzioni.md
@@ -31,9 +31,11 @@ semplice cosa fanno e quali parametri accettano.
     dimensioni del template.
 
 ## `src/timeline.ts`
-- **`buildTimeline(mods)`**
+- **`buildTimeline(mods, totalDuration?)`**
   - Trasforma le modifiche del template in una lista ordinata di segmenti,
     aggiungendo filler e outro dove necessario.
+  - Se viene fornita `totalDuration`, eventuali spazi vuoti finali sono
+    riempiti con un segmento filler.
 
 ## `src/template.ts`
 - **`loadTemplate()`**

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ import { sendFinalVideo } from "./share";
   })();
 
   // timeline
-  const timeline = buildTimeline(mods);
+  const timeline = buildTimeline(mods, data.duration);
   console.log("[LOG] Timeline:");
   timeline.forEach((seg) => {
     const label = seg.kind === "image" ? `image #${seg.index}` : seg.kind;

--- a/src/timeline.test.ts
+++ b/src/timeline.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTimeline } from "./timeline";
+import { HOLD_EXTRA_MS } from "./config";
+
+test("buildTimeline fills final gap with filler", () => {
+  const mods: any = {
+    "Immagine-0": "1", // trigger slide presence
+    "Slide_0.time": 0,
+    "Slide_0.duration": 2,
+    "Testo-0": "ciao",
+    "Outro.duration": 1,
+  };
+
+  const timeline = buildTimeline(mods, 5);
+  const last = timeline[timeline.length - 1];
+  assert.equal(last.kind, "filler");
+  const expectedTail = 5 - (2 + HOLD_EXTRA_MS / 1000 + 1);
+  assert.ok(Math.abs(last.duration - expectedTail) < 1e-6);
+});


### PR DESCRIPTION
## Summary
- allow `buildTimeline` to accept total duration and pad final gaps with filler segments
- pass template duration when building timeline in main
- document new parameter and add timeline test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a6bb2554833099a77145ef85cad2