### PR TITLE
Fix transparent padding for logo images

### DIFF
--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -89,6 +89,6 @@ test("image fit contain scales with aspect ratio", (t) => {
   const fchain = captured![idx + 1];
   assert.equal(
     fchain,
-    `[1:v]scale=100:50:force_original_aspect_ratio=decrease,pad=100:50:(ow-iw)/2:(oh-ih)/2[s0];[0:v][s0]overlay=x=0:y=0[v1]`
+    `[1:v]scale=100:50:force_original_aspect_ratio=decrease,format=rgba,pad=100:50:(ow-iw)/2:(oh-ih)/2:color=black@0[s0];[0:v][s0]overlay=x=0:y=0[v1]`
   );
 });

--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -132,7 +132,7 @@ export function renderTemplateElement(
     if (w || h) {
       const fit = el.fit;
       if (fit === "contain" && w && h) {
-        filter = `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2[s0];`;
+        filter = `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,format=rgba,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2:color=black@0[s0];`;
       } else {
         const sw = w ?? -1;
         const sh = h ?? -1;
@@ -251,7 +251,7 @@ export function renderTemplateSlide(
       if (w || h) {
         const fit = el.fit;
         if (fit === "contain" && w && h) {
-          filter += `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2[s${idx}];`;
+          filter += `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,format=rgba,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2:color=black@0[s${idx}];`;
         } else {
           const sw = w ?? -1;
           const sh = h ?? -1;


### PR DESCRIPTION
## Summary
- Avoid black borders around logo by padding with transparent background when images use `fit: "contain"`
- Adjust related test to expect transparent padding chain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b1a53e808330b62941357f8fca15