### PR TITLE
Stop adding filler after outro

### DIFF
--- a/docs/funzioni.md
+++ b/docs/funzioni.md
@@ -34,8 +34,8 @@ semplice cosa fanno e quali parametri accettano.
 - **`buildTimeline(mods, totalDuration?)`**
   - Trasforma le modifiche del template in una lista ordinata di segmenti,
     aggiungendo filler e outro dove necessario.
-  - Se viene fornita `totalDuration`, eventuali spazi vuoti finali sono
-    riempiti con un segmento filler.
+  - Il video termina sempre con l'outro; `totalDuration` viene usata solo per
+    inserire eventuali filler prima dell'outro.
 
 ## `src/template.ts`
 - **`loadTemplate()`**

--- a/src/timeline.test.ts
+++ b/src/timeline.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { buildTimeline } from "./timeline";
 import { HOLD_EXTRA_MS } from "./config";
 
-test("buildTimeline fills final gap with filler", () => {
+test("buildTimeline ends with outro without tail filler", () => {
   const mods: any = {
     "Immagine-0": "1", // trigger slide presence
     "Slide_0.time": 0,
@@ -14,7 +14,9 @@ test("buildTimeline fills final gap with filler", () => {
 
   const timeline = buildTimeline(mods, 5);
   const last = timeline[timeline.length - 1];
-  assert.equal(last.kind, "filler");
-  const expectedTail = 5 - (2 + HOLD_EXTRA_MS / 1000 + 1);
-  assert.ok(Math.abs(last.duration - expectedTail) < 1e-6);
+  assert.equal(last.kind, "outro");
+  const expectedTotal = 2 + HOLD_EXTRA_MS / 1000 + 1;
+  assert.ok(Math.abs(
+    timeline.reduce((sum, s) => sum + s.duration, 0) - expectedTotal
+  ) < 1e-6);
 });

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -10,8 +10,8 @@ import { Modifications, Segment } from "./types";
  * segmenti di riempimento per eventuali gap e aggiunge l'outro finale.
  *
  * @param mods Mappa chiave/valore proveniente dal template.
- * @param totalDuration Durata complessiva desiderata del video. Eventuali
- *        spazi vuoti finali verranno riempiti con un segmento filler.
+ * @param totalDuration Durata complessiva desiderata del video. Viene usata
+ *        solo per colmare eventuali gap prima dell'outro.
  * @returns Lista ordinata di segmenti da renderizzare.
  */
 export function buildTimeline(
@@ -93,19 +93,6 @@ export function buildTimeline(
     text: outroText,
   });
   cursorSched += outroDur;
-
-  if (totalDuration && totalDuration > cursorSched + MIN_FILLER_SEC) {
-    const tail = totalDuration - cursorSched;
-    timeline.push({
-      kind: "filler",
-      start: cursorSched,
-      duration: tail,
-      text: "",
-      tts: null,
-      img: null,
-    });
-    cursorSched += tail;
-  }
 
   return timeline;
 }


### PR DESCRIPTION
## Summary
- Prevent buildTimeline from appending tail filler after the outro, ensuring the video stops when the outro ends
- Update documentation and tests to reflect new timeline behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b57a1cc4833097169c2b193cb2ae