### PR TITLE
Fix vmin unit scaling for template elements

### DIFF
--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -92,3 +92,37 @@ test("image fit contain scales with aspect ratio", (t) => {
     `[1:v]scale=100:50:force_original_aspect_ratio=decrease,format=rgba,pad=100:50:(ow-iw)/2:(oh-ih)/2:color=black@0[s0];[0:v][s0]overlay=x=0:y=0[v1]`
   );
 });
+
+test("vmin units use smaller viewport dimension as percent", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "text",
+        text: "copy",
+        shadow_color: "#000000",
+        shadow_x: "1 vmin",
+        shadow_y: "1 vmin",
+        font_size_minimum: "1 vmin",
+        font_size_maximum: "2 vmin",
+        font_family: "Archivo",
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 200, videoH: 100, fonts: { Archivo: "C:/fonts/font.ttf" } }
+  );
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes("shadowx=1:shadowy=1"));
+  assert.ok(fc.includes("fontsize=2"));
+});

--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -37,7 +37,8 @@ function dimToPx(
   ) {
     const v = parseFloat(String(val));
     const ref = Math.min(videoW, videoH);
-    return Math.round(v * ref);
+    // CSS vmin units are percentages of the smaller viewport dimension
+    return Math.round((v / 100) * ref);
   }
   const n = parseFloat(String(val));
   return isNaN(n) ? undefined : Math.round(n);


### PR DESCRIPTION
## Summary
- interpret `vmin` CSS units as percentage of the smaller video dimension
- add regression test ensuring font size and shadow offsets use vmin correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1c902c4833089eb1b4c82297cf4