### PR TITLE
feat: add pan animation for images

### DIFF
--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -1,6 +1,6 @@
 import { runFFmpeg } from "../ffmpeg/run";
 import { parsePercent } from "../utils/num";
-import { ffmpegSafePath } from "../utils/ffmpeg";
+import { ffmpegSafePath, ffmpegEscapeExpr } from "../utils/ffmpeg";
 import { escDrawText, fitText } from "../utils/text";
 
 function normalizeColor(c: string): string {
@@ -182,7 +182,31 @@ export function renderTemplateElement(
     args.push("-loop", "1", "-t", `${duration}`, "-i", el.file);
     const src = `[2:v]`;
     let imgLbl = src;
-    if (w || h) {
+    const anims = Array.isArray(el.animations) ? el.animations : [];
+    const pan = anims.find((a) => a.type === "pan");
+    const fade = anims.find((a) => a.type === "fade");
+
+    if (pan) {
+      const start = typeof pan.time === "number" ? pan.time : 0;
+      const dur = typeof pan.duration === "number" ? pan.duration : duration;
+      const vw = w ?? videoW;
+      const vh = h ?? videoH;
+      const prog = `(min(max((t-${start})/${dur},0),1))`;
+      const sx = parsePercent(pan.start_x ?? "50%");
+      const sy = parsePercent(pan.start_y ?? "50%");
+      const ex = parsePercent(pan.end_x ?? pan.start_x ?? "50%");
+      const ey = parsePercent(pan.end_y ?? pan.start_y ?? "50%");
+      const ss = parsePercent(pan.start_scale ?? "100%");
+      const es = parsePercent(pan.end_scale ?? pan.start_scale ?? "100%");
+      const zoomExpr = `(${ss}+(${es - ss})*${prog})`;
+      const xExpr = `(iw*${zoomExpr}-${vw})*(${sx}+(${ex - sx})*${prog})`;
+      const yExpr = `(ih*${zoomExpr}-${vh})*(${sy}+(${ey - sy})*${prog})`;
+      const zoom = ffmpegEscapeExpr(zoomExpr);
+      const xPan = ffmpegEscapeExpr(xExpr);
+      const yPan = ffmpegEscapeExpr(yExpr);
+      filter = `${src}scale=iw*${zoom}:ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[p0];`;
+      imgLbl = "[p0]";
+    } else if (w || h) {
       const fit = el.fit;
       if (fit === "contain" && w && h) {
         filter = `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,format=rgba,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2:color=black@0[s0];`;
@@ -196,10 +220,9 @@ export function renderTemplateElement(
       filter = `${src}scale=${videoW}:${videoH}:force_original_aspect_ratio=increase,crop=${videoW}:${videoH}[s0];`;
       imgLbl = "[s0]";
     }
-    const anim = Array.isArray(el.animations) ? el.animations[0] : undefined;
-    if (anim && anim.type === "fade") {
-      const start = typeof anim.time === "number" ? anim.time : 0;
-      const dur = typeof anim.duration === "number" ? anim.duration : 1;
+    if (fade) {
+      const start = typeof fade.time === "number" ? fade.time : 0;
+      const dur = typeof fade.duration === "number" ? fade.duration : 1;
       filter += `${imgLbl}format=rgba,fade=t=in:st=${start.toFixed(3)}:d=${dur.toFixed(3)}:alpha=1[f0];`;
       imgLbl = "[f0]";
     }
@@ -331,7 +354,31 @@ export function renderTemplateSlide(
 
       const src = `[${imgInput}:v]`;
       let imgLbl = src;
-      if (w || h) {
+      const anims = Array.isArray(el.animations) ? el.animations : [];
+      const pan = anims.find((a) => a.type === "pan");
+      const fade = anims.find((a) => a.type === "fade");
+
+      if (pan) {
+        const start = typeof pan.time === "number" ? pan.time : 0;
+        const dur = typeof pan.duration === "number" ? pan.duration : duration;
+        const vw = w ?? videoW;
+        const vh = h ?? videoH;
+        const prog = `(min(max((t-${start})/${dur},0),1))`;
+        const sx = parsePercent(pan.start_x ?? "50%");
+        const sy = parsePercent(pan.start_y ?? "50%");
+        const ex = parsePercent(pan.end_x ?? pan.start_x ?? "50%");
+        const ey = parsePercent(pan.end_y ?? pan.start_y ?? "50%");
+        const ss = parsePercent(pan.start_scale ?? "100%");
+        const es = parsePercent(pan.end_scale ?? pan.start_scale ?? "100%");
+        const zoomExpr = `(${ss}+(${es - ss})*${prog})`;
+        const xExpr = `(iw*${zoomExpr}-${vw})*(${sx}+(${ex - sx})*${prog})`;
+        const yExpr = `(ih*${zoomExpr}-${vh})*(${sy}+(${ey - sy})*${prog})`;
+        const zoom = ffmpegEscapeExpr(zoomExpr);
+        const xPan = ffmpegEscapeExpr(xExpr);
+        const yPan = ffmpegEscapeExpr(yExpr);
+        filter += `${src}scale=iw*${zoom}:ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[s${idx}];`;
+        imgLbl = `[s${idx}]`;
+      } else if (w || h) {
         const fit = el.fit;
         if (fit === "contain" && w && h) {
           filter += `${src}scale=${w}:${h}:force_original_aspect_ratio=decrease,format=rgba,pad=${w}:${h}:(ow-iw)/2:(oh-ih)/2:color=black@0[s${idx}];`;
@@ -345,10 +392,9 @@ export function renderTemplateSlide(
         filter += `${src}scale=${videoW}:${videoH}:force_original_aspect_ratio=increase,crop=${videoW}:${videoH}[s${idx}];`;
         imgLbl = `[s${idx}]`;
       }
-      const anim = Array.isArray(el.animations) ? el.animations[0] : undefined;
-      if (anim && anim.type === "fade") {
-        const start = typeof anim.time === "number" ? anim.time : 0;
-        const dur = typeof anim.duration === "number" ? anim.duration : 1;
+      if (fade) {
+        const start = typeof fade.time === "number" ? fade.time : 0;
+        const dur = typeof fade.duration === "number" ? fade.duration : 1;
         filter += `${imgLbl}format=rgba,fade=t=in:st=${start.toFixed(3)}:d=${dur.toFixed(3)}:alpha=1[f${idx}];`;
         imgLbl = `[f${idx}]`;
       }

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -8,3 +8,7 @@ export function ffmpegSafePath(p: string): string {
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }
+
+export function ffmpegEscapeExpr(expr: string): string {
+  return expr.replace(/,/g, "\\,");
+}


### PR DESCRIPTION
## Summary
- support pan/zoom animations for image elements
- combine pan with existing fade effect during image overlays
- escape FFmpeg expressions so pan animations parse correctly

## Testing
- `npm test`
- `npm start` *(fails: request to staging.merlino.video ... ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c39f88a08330a48de76d0274c49e