### PR TITLE
Support multiline text wipe animations

### DIFF
--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -127,6 +127,67 @@ test("vmin units use smaller viewport dimension as percent", (t) => {
   assert.ok(fc.includes("fontsize=2"));
 });
 
+test("text includes letter spacing when specified", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "text",
+        text: "abc",
+        letter_spacing: "200%",
+        font_family: "Archivo",
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 100, videoH: 100, fonts: { Archivo: "C:/fonts/font.ttf" } }
+  );
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes(":spacing="));
+});
+
+test("multiline wipe uses xfade per line", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "text",
+        text: "hello world",
+        width: "20%",
+        font_size: 20,
+        animations: [{ type: "text-reveal", x_anchor: "0%" }],
+        font_family: "Archivo",
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 100, videoH: 100, fonts: { Archivo: "C:/fonts/font.ttf" } }
+  );
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes("[L0_0_off][L0_0_on]xfade"));
+  assert.ok(fc.includes("[L0_1_off][L0_1_on]xfade"));
+});
+
 test("pan animation escapes commas in ffmpeg expressions", (t) => {
   let captured: string[] | undefined;
   const runMod = require("../ffmpeg/run");

--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -145,28 +145,66 @@ export function renderTemplateElement(
     const shadowX = dimToPx(el.shadow_x, videoW, videoW, videoH) ?? 0;
     const shadowY = dimToPx(el.shadow_y, videoH, videoW, videoH) ?? 0;
     const lineSpacing = Math.round(fontsize * (lineFactor - 1));
+    const letterSpacing = el.letter_spacing
+      ? Math.round((parsePercent(el.letter_spacing) - 1) * fontsize)
+      : 0;
     const extra =
       (boxColor ? `:box=1:boxcolor=${boxColor}` : "") +
       (shadowColor
         ? `:shadowcolor=${shadowColor}:shadowx=${shadowX}:shadowy=${shadowY}`
         : "") +
-      (lineSpacing ? `:line_spacing=${lineSpacing}` : "");
+      (lineSpacing ? `:line_spacing=${lineSpacing}` : "") +
+      (letterSpacing ? `:spacing=${letterSpacing}` : "");
     const anim = Array.isArray(el.animations) ? el.animations[0] : undefined;
     if (anim && (anim.type === "wipe" || anim.type === "text-reveal")) {
       const dir = pickWipeDirection(anim);
       const start = typeof anim.time === "number" ? anim.time : 0;
       const dur = typeof anim.duration === "number" ? anim.duration : 0.6;
-      filter =
-        `color=c=black@0.0:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=rgba,setsar=1[t_can];` +
-        `[t_can]drawtext=fontfile='${font}':text='${text}':x=${finalX}:y=${finalY}:fontsize=${fontsize}:fontcolor=${color}${extra}[t_rgba];` +
-        `[t_rgba]split=2[t_rgb][t_forA];` +
-        `[t_forA]alphaextract,format=gray,setsar=1[t_Aorig];` +
-        `color=c=black:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t_off];` +
-        `color=c=white:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t_on];` +
-        `[t_off][t_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[t_wipe];` +
-        `[t_Aorig][t_wipe]blend=all_mode=multiply[t_A];` +
-        `[t_rgb][t_A]alphamerge[t_ready];` +
-        `[0:v][t_ready]overlay=x=0:y=0[v]`;
+      const lines = fitted.text.split("\n");
+      if (lines.length > 1) {
+        const lineH = fontsize + lineSpacing;
+        const extraLine =
+          (boxColor ? `:box=1:boxcolor=${boxColor}` : "") +
+          (shadowColor
+            ? `:shadowcolor=${shadowColor}:shadowx=${shadowX}:shadowy=${shadowY}`
+            : "") +
+          (letterSpacing ? `:spacing=${letterSpacing}` : "");
+        const parts: string[] = [];
+        let inLbl = "0:v";
+        for (let i = 0; i < lines.length; i++) {
+          const safe = escDrawText(lines[i]);
+          const lineY = finalY + i * lineH;
+          parts.push(`color=c=black@0.0:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=rgba,setsar=1[L${i}_can]`);
+          parts.push(
+            `[L${i}_can]drawtext=fontfile='${font}':text='${safe}':x=${finalX}:y=h-text_h-1:fontsize=${fontsize}:fontcolor=${color}${extraLine}[L${i}_rgba]`
+          );
+          parts.push(`[L${i}_rgba]split=2[L${i}_rgb][L${i}_forA]`);
+          parts.push(`[L${i}_forA]alphaextract,format=gray,setsar=1[L${i}_Aorig]`);
+          parts.push(`color=c=black:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=gray,setsar=1[L${i}_off]`);
+          parts.push(`color=c=white:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=gray,setsar=1[L${i}_on]`);
+          parts.push(
+            `[L${i}_off][L${i}_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[L${i}_wipe]`
+          );
+          parts.push(`[L${i}_Aorig][L${i}_wipe]blend=all_mode=multiply[L${i}_A]`);
+          parts.push(`[L${i}_rgb][L${i}_A]alphamerge[L${i}_ready]`);
+          const outLbl = i === lines.length - 1 ? "[v]" : `[L${i}_out]`;
+          parts.push(`[${inLbl}][L${i}_ready]overlay=x=0:y=${lineY}${outLbl}`);
+          inLbl = i === lines.length - 1 ? "v" : `L${i}_out`;
+        }
+        filter = parts.join(";");
+      } else {
+        filter =
+          `color=c=black@0.0:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=rgba,setsar=1[t_can];` +
+          `[t_can]drawtext=fontfile='${font}':text='${text}':x=${finalX}:y=${finalY}:fontsize=${fontsize}:fontcolor=${color}${extra}[t_rgba];` +
+          `[t_rgba]split=2[t_rgb][t_forA];` +
+          `[t_forA]alphaextract,format=gray,setsar=1[t_Aorig];` +
+          `color=c=black:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t_off];` +
+          `color=c=white:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t_on];` +
+          `[t_off][t_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[t_wipe];` +
+          `[t_Aorig][t_wipe]blend=all_mode=multiply[t_A];` +
+          `[t_rgb][t_A]alphamerge[t_ready];` +
+          `[0:v][t_ready]overlay=x=0:y=0[v]`;
+      }
     } else {
       let alphaPart = "";
       if (anim && anim.type === "fade") {
@@ -317,28 +355,66 @@ export function renderTemplateSlide(
       const shadowX = dimToPx(el.shadow_x, videoW, videoW, videoH) ?? 0;
       const shadowY = dimToPx(el.shadow_y, videoH, videoW, videoH) ?? 0;
       const lineSpacing = Math.round(fontsize * (lineFactor - 1));
+      const letterSpacing = el.letter_spacing
+        ? Math.round((parsePercent(el.letter_spacing) - 1) * fontsize)
+        : 0;
       const extra =
         (boxColor ? `:box=1:boxcolor=${boxColor}` : "") +
         (shadowColor
           ? `:shadowcolor=${shadowColor}:shadowx=${shadowX}:shadowy=${shadowY}`
           : "") +
-        (lineSpacing ? `:line_spacing=${lineSpacing}` : "");
+        (lineSpacing ? `:line_spacing=${lineSpacing}` : "") +
+        (letterSpacing ? `:spacing=${letterSpacing}` : "");
       const anim = Array.isArray(el.animations) ? el.animations[0] : undefined;
       if (anim && (anim.type === "wipe" || anim.type === "text-reveal")) {
         const dir = pickWipeDirection(anim);
         const start = typeof anim.time === "number" ? anim.time : 0;
         const dur = typeof anim.duration === "number" ? anim.duration : 0.6;
-        filter +=
-          `color=c=black@0.0:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=rgba,setsar=1[t${idx}_can];` +
-          `[t${idx}_can]drawtext=fontfile='${font}':text='${text}':x=${fx}:y=${fy}:fontsize=${fontsize}:fontcolor=${color}${extra}[t${idx}_rgba];` +
-          `[t${idx}_rgba]split=2[t${idx}_rgb][t${idx}_forA];` +
-          `[t${idx}_forA]alphaextract,format=gray,setsar=1[t${idx}_Aorig];` +
-          `color=c=black:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t${idx}_off];` +
-          `color=c=white:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t${idx}_on];` +
-          `[t${idx}_off][t${idx}_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[t${idx}_wipe];` +
-          `[t${idx}_Aorig][t${idx}_wipe]blend=all_mode=multiply[t${idx}_A];` +
-          `[t${idx}_rgb][t${idx}_A]alphamerge[t${idx}_ready];` +
-          `${cur}[t${idx}_ready]overlay=x=0:y=0${outLbl};`;
+        const lines = fitted.text.split("\n");
+        if (lines.length > 1) {
+          const lineH = fontsize + lineSpacing;
+          const extraLine =
+            (boxColor ? `:box=1:boxcolor=${boxColor}` : "") +
+            (shadowColor
+              ? `:shadowcolor=${shadowColor}:shadowx=${shadowX}:shadowy=${shadowY}`
+              : "") +
+            (letterSpacing ? `:spacing=${letterSpacing}` : "");
+          const parts: string[] = [];
+          let inLbl = cur.slice(1, -1);
+          for (let i = 0; i < lines.length; i++) {
+            const safe = escDrawText(lines[i]);
+            const lineY = fy + i * lineH;
+            parts.push(`color=c=black@0.0:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=rgba,setsar=1[L${idx}_${i}_can]`);
+            parts.push(
+              `[L${idx}_${i}_can]drawtext=fontfile='${font}':text='${safe}':x=${fx}:y=h-text_h-1:fontsize=${fontsize}:fontcolor=${color}${extraLine}[L${idx}_${i}_rgba]`
+            );
+            parts.push(`[L${idx}_${i}_rgba]split=2[L${idx}_${i}_rgb][L${idx}_${i}_forA]`);
+            parts.push(`[L${idx}_${i}_forA]alphaextract,format=gray,setsar=1[L${idx}_${i}_Aorig]`);
+            parts.push(`color=c=black:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=gray,setsar=1[L${idx}_${i}_off]`);
+            parts.push(`color=c=white:s=${videoW}x${lineH}:r=${fps}:d=${duration},format=gray,setsar=1[L${idx}_${i}_on]`);
+            parts.push(
+              `[L${idx}_${i}_off][L${idx}_${i}_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[L${idx}_${i}_wipe]`
+            );
+            parts.push(`[L${idx}_${i}_Aorig][L${idx}_${i}_wipe]blend=all_mode=multiply[L${idx}_${i}_A]`);
+            parts.push(`[L${idx}_${i}_rgb][L${idx}_${i}_A]alphamerge[L${idx}_${i}_ready]`);
+            const outTmp = i === lines.length - 1 ? outLbl : `[L${idx}_${i}_out]`;
+            parts.push(`[${inLbl}][L${idx}_${i}_ready]overlay=x=0:y=${lineY}${outTmp}`);
+            inLbl = i === lines.length - 1 ? outLbl.slice(1, -1) : `L${idx}_${i}_out`;
+          }
+          filter += parts.join(";");
+        } else {
+          filter +=
+            `color=c=black@0.0:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=rgba,setsar=1[t${idx}_can];` +
+            `[t${idx}_can]drawtext=fontfile='${font}':text='${text}':x=${fx}:y=${fy}:fontsize=${fontsize}:fontcolor=${color}${extra}[t${idx}_rgba];` +
+            `[t${idx}_rgba]split=2[t${idx}_rgb][t${idx}_forA];` +
+            `[t${idx}_forA]alphaextract,format=gray,setsar=1[t${idx}_Aorig];` +
+            `color=c=black:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t${idx}_off];` +
+            `color=c=white:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=gray,setsar=1[t${idx}_on];` +
+            `[t${idx}_off][t${idx}_on]xfade=transition=${dir}:duration=${dur.toFixed(3)}:offset=${start.toFixed(3)}[t${idx}_wipe];` +
+            `[t${idx}_Aorig][t${idx}_wipe]blend=all_mode=multiply[t${idx}_A];` +
+            `[t${idx}_rgb][t${idx}_A]alphamerge[t${idx}_ready];` +
+            `${cur}[t${idx}_ready]overlay=x=0:y=0${outLbl};`;
+        }
       } else {
         let alphaPart = "";
         if (anim && anim.type === "fade") {


### PR DESCRIPTION
## Summary
- split multiline text into separate line canvases and wipe each line via xfade
- exercise per-line text wipe in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c90979d0833095fc87a3a0b9236b