### PR TITLE
fix: specify width/height in pan zoom filter

### DIFF
--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -242,7 +242,7 @@ export function renderTemplateElement(
       const zoom = ffmpegEscapeExpr(zoomExpr);
       const xPan = ffmpegEscapeExpr(xExpr);
       const yPan = ffmpegEscapeExpr(yExpr);
-      filter = `${src}scale=iw*${zoom}:ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[p0];`;
+      filter = `${src}scale=w=iw*${zoom}:h=ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[p0];`;
 
       imgLbl = "[p0]";
     } else if (w || h) {
@@ -401,7 +401,8 @@ export function renderTemplateSlide(
             parts.push(`[${inLbl}][L${idx}_${i}_ready]overlay=x=0:y=${lineY}${outTmp}`);
             inLbl = i === lines.length - 1 ? outLbl.slice(1, -1) : `L${idx}_${i}_out`;
           }
-          filter += parts.join(";");
+          // ensure the text segment ends with a separator so following filters parse correctly
+          filter += parts.join(";") + ";";
         } else {
           filter +=
             `color=c=black@0.0:s=${videoW}x${videoH}:r=${fps}:d=${duration},format=rgba,setsar=1[t${idx}_can];` +
@@ -453,7 +454,7 @@ export function renderTemplateSlide(
         const zoom = ffmpegEscapeExpr(zoomExpr);
         const xPan = ffmpegEscapeExpr(xExpr);
         const yPan = ffmpegEscapeExpr(yExpr);
-        filter += `${src}scale=iw*${zoom}:ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[s${idx}];`;
+        filter += `${src}scale=w=iw*${zoom}:h=ih*${zoom}:eval=frame,crop=${vw}:${vh}:x=${xPan}:y=${yPan},setsar=1[s${idx}];`;
 
         imgLbl = `[s${idx}]`;
       } else if (w || h) {


### PR DESCRIPTION
## Summary
- fix pan zoom filter by naming width & height options in scale to properly apply eval=frame
- end multiline text overlay chains with a separator to prevent filter parsing errors

## Testing
- `npm test`
- `npm start` *(fails: Impossibile scaricare ... request to remote resources failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cfaa7be08330a6875cddd429c36c