### PR TITLE
Fix shadow color format for text rendering

### DIFF
--- a/src/renderers/templateObject.ts
+++ b/src/renderers/templateObject.ts
@@ -11,10 +11,8 @@ function normalizeColor(c: string): string {
     const g = toHex(m[2]!);
     const b = toHex(m[3]!);
     if (m[4]) {
-      const a = Math.round(parseFloat(m[4]!) * 255)
-        .toString(16)
-        .padStart(2, "0");
-      return `#${r}${g}${b}${a}`;
+      const a = parseFloat(m[4]!).toString();
+      return `#${r}${g}${b}@${a}`;
     }
     return `#${r}${g}${b}`;
   }


### PR DESCRIPTION
## Summary
- convert rgba colors to FFmpeg-friendly `#RRGGBB@alpha` format
- ensure text shadows from templates are rendered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3d524908330940311b12b0f2609