### PR TITLE
Fix shadow color format for text rendering

### DIFF
--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -127,6 +127,36 @@ test("vmin units use smaller viewport dimension as percent", (t) => {
   assert.ok(fc.includes("fontsize=2"));
 });
 
+test("shadow blur applies to alpha channel", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "text",
+        text: "blurred",
+        shadow_color: "#000000",
+        shadow_blur: 4,
+        font_family: "Archivo",
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 200, videoH: 100, fonts: { Archivo: "C:/fonts/font.ttf" } }
+  );
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes("boxblur=4:4:4"));
+});
+
 test("text includes letter spacing when specified", (t) => {
   let captured: string[] | undefined;
   const runMod = require("../ffmpeg/run");
@@ -229,4 +259,40 @@ test("pan animation escapes commas in ffmpeg expressions", (t) => {
   assert.notEqual(idx, -1);
   const fc = captured![idx + 1];
   assert.ok(fc.includes("min(max((t-0)/1\\,0)\\,1)"));
+});
+
+test("shade element uses shadeChain", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  const filtersMod = require("../ffmpeg/filters");
+  let called = false;
+  t.mock.method(filtersMod, "shadeChain", (...args: any[]) => {
+    called = true;
+    return "format=rgba,geq=r='0':g='0':b='0':a='255'";
+  });
+
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "shade",
+        strength: 0.4,
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 100, videoH: 100, fonts: {} }
+  );
+
+  assert.ok(called);
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes("geq"));
+  assert.ok(fc.includes("overlay"));
 });


### PR DESCRIPTION
## Summary
- blur text shadow alpha so drop shadows render visibly
- add regression test for blurred shadow layer
- support `shade` elements and use `shadeChain` to overlay gradient shadows on slides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3d524908330940311b12b0f2609