### PR TITLE
Support image shadows in slide renderer

### DIFF
--- a/src/parser/templateParser.ts
+++ b/src/parser/templateParser.ts
@@ -49,6 +49,10 @@ export interface ImageElement extends BaseVisual {
   type: "image";
   source: string;
   fit?: string;
+  shadow_color?: string;
+  shadow_blur?: string;
+  shadow_x?: string;
+  shadow_y?: string;
 }
 
 export interface GradientStop {
@@ -126,7 +130,16 @@ function mapVisual(el: any): VisualElement | null {
     case "video":
       return { ...common, type: "video", source: el.source } as VideoElement;
     case "image":
-      return { ...common, type: "image", source: el.source, fit: el.fit } as ImageElement;
+      return {
+        ...common,
+        type: "image",
+        source: el.source,
+        fit: el.fit,
+        shadow_color: el.shadow_color,
+        shadow_blur: el.shadow_blur,
+        shadow_x: el.shadow_x,
+        shadow_y: el.shadow_y,
+      } as ImageElement;
     case "shape":
       return {
         ...common,

--- a/src/renderers/templateObject.test.ts
+++ b/src/renderers/templateObject.test.ts
@@ -93,6 +93,40 @@ test("image fit contain scales with aspect ratio", (t) => {
   );
 });
 
+test("image shadow is rendered with blur and offset", (t) => {
+  let captured: string[] | undefined;
+  const runMod = require("../ffmpeg/run");
+  t.mock.method(runMod, "runFFmpeg", (args: string[]) => {
+    captured = args;
+  });
+
+  writeFileSync("dummy.png", "");
+  const { renderTemplateSlide } = require("./templateObject");
+  renderTemplateSlide(
+    [
+      {
+        type: "image",
+        file: "dummy.png",
+        shadow_color: "#000000",
+        shadow_x: 5,
+        shadow_y: 6,
+        shadow_blur: 4,
+      },
+    ],
+    1,
+    "out.mp4",
+    { fps: 30, videoW: 200, videoH: 100, fonts: {} }
+  );
+  unlinkSync("dummy.png");
+
+  assert.ok(captured);
+  const idx = captured!.indexOf("-filter_complex");
+  assert.notEqual(idx, -1);
+  const fc = captured![idx + 1];
+  assert.ok(fc.includes("boxblur=4:4:4"));
+  assert.ok(fc.includes("overlay=x=5:y=6"));
+});
+
 test("vmin units use smaller viewport dimension as percent", (t) => {
   let captured: string[] | undefined;
   const runMod = require("../ffmpeg/run");


### PR DESCRIPTION
## Summary
- allow image elements to render drop shadows with optional blur and offsets
- propagate shadow properties for images through the template parser
- test image shadow rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f72f17a48330a3a7177abca652f3