### PR TITLE
Handle stray asset names and keep text visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ invocazioni al motore video vengono costruite automaticamente.
 
 ## Dipendenze
 - Node.js ≥ 18
-- [ffmpeg-static](https://www.npmjs.com/package/ffmpeg-static) installato
-  automaticamente con le dipendenze **oppure** un'installazione di FFmpeg
-  disponibile nel sistema e indicata tramite la variabile d'ambiente
-  `FFMPEG_PATH`
+- FFmpeg installato nel sistema oppure indicato tramite variabile
+  d'ambiente `FFMPEG_PATH`
 
 Installa i pacchetti del progetto con:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ invocazioni al motore video vengono costruite automaticamente.
 
 ## Dipendenze
 - Node.js ≥ 18
-- FFmpeg installato nel sistema oppure indicato tramite variabile
-  d'ambiente `FFMPEG_PATH`
+- [ffmpeg-static](https://www.npmjs.com/package/ffmpeg-static) installato
+  automaticamente con le dipendenze **oppure** un'installazione di FFmpeg
+  disponibile nel sistema e indicata tramite la variabile d'ambiente
+  `FFMPEG_PATH`
 
 Installa i pacchetti del progetto con:
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "start:reuse:dir": "npm run build && node dist/main.js --reuse-segs --segsDir src/temp",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ffmpeg-static": "^5.2.0"
+  },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "typescript": "^5.5.0"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "start:reuse:dir": "npm run build && node dist/main.js --reuse-segs --segsDir src/temp",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
-  "dependencies": {
-    "ffmpeg-static": "^5.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.11.0",
     "typescript": "^5.5.0"

--- a/src/fetchAssets.ts
+++ b/src/fetchAssets.ts
@@ -49,11 +49,8 @@ async function downloadFile(url: string, outPath: string) {
 export async function fetchAssets() {
   const mods = loadModifications() || {};
 
-  clearDir(paths.audio);
-  clearDir(paths.images);
-  clearDir(paths.tts);
-  clearDir(paths.fonts);
-
+  clearDir(paths.downloads);
+  ensureDir(paths.downloads);
   ensureDir(paths.audio);
   ensureDir(paths.images);
   ensureDir(paths.tts);

--- a/src/fetchAssets.ts
+++ b/src/fetchAssets.ts
@@ -72,24 +72,24 @@ export async function fetchAssets() {
 
   // TTS
   for (const key of Object.keys(mods)) {
-    if (key.startsWith("TTS-")) {
-      const url = String(mods[key] ?? "");
+    const m = key.match(/^TTS-(\d+)$/);
+    if (m) {
+      const url = String(mods[key] ?? "").trim();
       if (url.startsWith("http")) {
-        const idx = key.split("-")[1];
-        await downloadFile(url, join(paths.tts, `tts-${idx}.mp3`));
+        await downloadFile(url, join(paths.tts, `tts-${m[1]}.mp3`));
       }
     }
   }
 
   // Immagini
   for (const key of Object.keys(mods)) {
-    if (key.startsWith("Immagine-")) {
-      const url = String(mods[key] ?? "");
+    const m = key.match(/^Immagine-(\d+)$/);
+    if (m) {
+      const url = String(mods[key] ?? "").trim();
       if (url.startsWith("http")) {
-        const idx = key.split("-")[1];
         const ext = (url.split(".").pop()?.split("?")[0] || "jpg").toLowerCase();
         const safeExt = ext.length <= 5 ? ext : "jpg";
-        await downloadFile(url, join(paths.images, `img${idx}.${safeExt}`));
+        await downloadFile(url, join(paths.images, `img${m[1]}.${safeExt}`));
       }
     }
   }

--- a/src/fetchAssets.ts
+++ b/src/fetchAssets.ts
@@ -68,7 +68,7 @@ export async function fetchAssets() {
   // Audio di background
   const audioUrl = String(mods.Audio ?? "").trim();
   if (audioUrl.startsWith("http")) {
-    await downloadFile(audioUrl, join(paths.audio, "bg.mp3"));
+    await downloadFile(audioUrl, paths.bgAudio);
   }
 
   // TTS

--- a/src/fetchAssets.ts
+++ b/src/fetchAssets.ts
@@ -48,10 +48,8 @@ async function downloadFile(url: string, outPath: string) {
 export async function fetchAssets() {
   const mods = loadModifications() || {};
 
-  clearDir(paths.audio);
-  clearDir(paths.images);
-  clearDir(paths.tts);
-  clearDir(paths.fonts);
+  // Pulisce completamente la cartella di download per evitare artefatti (es. "npm" o "img=true")
+  clearDir(paths.downloads);
 
   ensureDir(paths.audio);
   ensureDir(paths.images);

--- a/src/fetchAssets.ts
+++ b/src/fetchAssets.ts
@@ -60,13 +60,13 @@ export async function fetchAssets() {
   ensureDir(paths.fonts);
 
   // Logo
-  const logoUrl = String(mods.Logo ?? "");
+  const logoUrl = String(mods.Logo ?? "").trim();
   if (logoUrl.startsWith("http")) {
     await downloadFile(logoUrl, join(paths.images, "logo.png"));
   }
 
   // Audio di background
-  const audioUrl = String(mods.Audio ?? "");
+  const audioUrl = String(mods.Audio ?? "").trim();
   if (audioUrl.startsWith("http")) {
     await downloadFile(audioUrl, join(paths.audio, "bg.mp3"));
   }
@@ -75,7 +75,7 @@ export async function fetchAssets() {
   for (const key of Object.keys(mods)) {
     const m = /^TTS-(\d+)$/.exec(key);
     if (m) {
-      const url = String(mods[key] ?? "");
+      const url = String(mods[key] ?? "").trim();
       if (url.startsWith("http")) {
         const idx = m[1];
         await downloadFile(url, join(paths.tts, `tts-${idx}.mp3`));
@@ -87,7 +87,7 @@ export async function fetchAssets() {
   for (const key of Object.keys(mods)) {
     const m = /^Immagine-(\d+)$/.exec(key);
     if (m) {
-      const url = String(mods[key] ?? "");
+      const url = String(mods[key] ?? "").trim();
       if (url.startsWith("http")) {
         const idx = m[1];
         const ext = (url.split(".").pop()?.split("?")[0] || "jpg").toLowerCase();
@@ -110,17 +110,17 @@ export async function fetchAssets() {
   tpl.elements.forEach((e) => collectFonts(e));
 
   async function downloadFont(family: string) {
-    const famParam = family.trim().replace(/\s+/g, "+");
+    const famParam = encodeURIComponent(family.trim()).replace(/%20/g, "+");
     try {
       const cssBuf = await httpGet(
-        `https://fonts.googleapis.com/css2?family=${encodeURIComponent(famParam)}`
+        `https://fonts.googleapis.com/css2?family=${famParam}`
       );
       const css = cssBuf.toString("utf8");
       const match = css.match(/url\((https:[^\)]+)\)/);
       if (!match) return;
       const fontUrl = match[1];
       const ext = fontUrl.split(".").pop()?.split("?")[0] || "ttf";
-      const safe = family.replace(/\s+/g, "_").toLowerCase();
+      const safe = family.trim().replace(/\s+/g, "_").toLowerCase();
       await downloadFile(fontUrl, join(paths.fonts, `${safe}.${ext}`));
     } catch (err) {
       console.warn(`Impossibile scaricare il font ${family}:`, err);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -3,17 +3,21 @@
 // ==============================
 import { join } from "path";
 
+const root = process.cwd();
+const downloads = join(root, "download");
+
 export const paths = {
-  root: process.cwd(),
-  temp: join(process.cwd(), "src", "temp"),
-  output: join(process.cwd(), "src", "output"),
-  images: join(process.cwd(), "download", "images"),
-  tts: join(process.cwd(), "download", "tts"),
-  audio: join(process.cwd(), "download", "audio"),
-  fonts: join(process.cwd(), "download", "fonts"),
-  templateDir: join(process.cwd(), "template"),
-  template: join(process.cwd(), "template", "template_horizontal.json"),
-  modifications: join(process.cwd(), "template", "risposta_horizontal.json"),
+  root,
+  downloads,
+  temp: join(root, "src", "temp"),
+  output: join(root, "src", "output"),
+  images: join(downloads, "images"),
+  tts: join(downloads, "tts"),
+  audio: join(downloads, "audio"),
+  fonts: join(downloads, "fonts"),
+  templateDir: join(root, "template"),
+  template: join(root, "template", "template_horizontal.json"),
+  modifications: join(root, "template", "risposta_horizontal.json"),
   // Resolve the FFmpeg binary:
   // 1. Respect an explicit env override
   // 2. Use `ffmpeg-static` if it's installed
@@ -28,8 +32,9 @@ export const paths = {
     }
   })(),
 
-  concatList: join(process.cwd(), "src", "temp", "concat.txt"),
-  finalVideo: join(process.cwd(), "src", "output", "final_output.mp4"),
-  get bgAudio() { return join(this.audio, "bg.mp3"); },
+  concatList: join(root, "src", "temp", "concat.txt"),
+  finalVideo: join(root, "src", "output", "final_output.mp4"),
+  get bgAudio() {
+    return join(this.audio, "bg.mp3");
+  },
 };
-

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 
 export const paths = {
   root: process.cwd(),
+  downloads: join(process.cwd(), "download"),
   temp: join(process.cwd(), "src", "temp"),
   output: join(process.cwd(), "src", "output"),
   images: join(process.cwd(), "download", "images"),

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,7 +5,6 @@ import { join } from "path";
 
 export const paths = {
   root: process.cwd(),
-  downloads: join(process.cwd(), "download"),
   temp: join(process.cwd(), "src", "temp"),
   output: join(process.cwd(), "src", "output"),
   images: join(process.cwd(), "download", "images"),

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -130,28 +130,19 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
 
       let cur = `tx_${i}`;
       if (tb.animations && tb.animations.length) {
-        for (let ai = 0; ai < tb.animations.length; ai++) {
-          const an = tb.animations[ai];
+        tb.animations.forEach((an, ai) => {
+          if ("reversed" in an && (an as any).reversed) return; // ignora animazioni "out"
           if (an.type === "fade") {
-            // ignore fade-out: text must stay visible until end of segment
-            if (an.reversed) continue;
-            const st =
-              typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
+            const st = typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
             const lbl = `tx_${i}_anim${ai}`;
-            f.push(
-              `[${cur}]fade=t=in:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`
-            );
+            f.push(`[${cur}]fade=t=in:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`);
             cur = lbl;
           } else if (an.type === "wipe" && needBlank) {
-            // Ignore wipe-out animations for the same reason
-            if ((an as any).reversed) continue;
             const lbl = `tx_${i}_anim${ai}`;
-            f.push(
-              `[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`
-            );
+            f.push(`[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`);
             cur = lbl;
           }
-        }
+        });
       }
 
       const outLbl = `v_txt${i}`;

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -132,14 +132,20 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
       if (tb.animations && tb.animations.length) {
         tb.animations.forEach((an, ai) => {
           if (an.type === "fade") {
-            const st = typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
-            const t = an.reversed ? "out" : "in";
+            // ignore fade-out: text must stay visible until end of segment
+            if (an.reversed) return;
+            const st =
+              typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
             const lbl = `tx_${i}_anim${ai}`;
-            f.push(`[${cur}]fade=t=${t}:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`);
+            f.push(
+              `[${cur}]fade=t=in:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`
+            );
             cur = lbl;
           } else if (an.type === "wipe" && needBlank) {
             const lbl = `tx_${i}_anim${ai}`;
-            f.push(`[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`);
+            f.push(
+              `[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`
+            );
             cur = lbl;
           }
         });

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -130,10 +130,11 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
 
       let cur = `tx_${i}`;
       if (tb.animations && tb.animations.length) {
-        tb.animations.forEach((an, ai) => {
+        for (let ai = 0; ai < tb.animations.length; ai++) {
+          const an = tb.animations[ai];
           if (an.type === "fade") {
             // ignore fade-out: text must stay visible until end of segment
-            if (an.reversed) return;
+            if (an.reversed) continue;
             const st =
               typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
             const lbl = `tx_${i}_anim${ai}`;
@@ -148,7 +149,7 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
             );
             cur = lbl;
           }
-        });
+        }
       }
 
       const outLbl = `v_txt${i}`;

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -103,9 +103,13 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
       const tb = slide.texts[i];
 
       // layer trasparente su cui disegnare il testo; il "blank" serve solo per xfade
-      const needBlank = tb.animations?.some((a) => a.type === "wipe") ?? false;
-      if (needBlank) {
-        f.push(`color=c=black@0:s=${W}x${H}:d=${dur},format=rgba[tx_${i}_blank]`);
+      const wipeAnims = tb.animations?.filter((a) => a.type === "wipe") ?? [];
+      if (wipeAnims.length) {
+        const blankDur = Math.min(
+          dur,
+          Math.max(...wipeAnims.map((a) => (a.time ?? 0) + a.duration))
+        );
+        f.push(`color=c=black@0:s=${W}x${H}:d=${blankDur},format=rgba[tx_${i}_blank]`);
       }
       f.push(`color=c=black@0:s=${W}x${H}:d=${dur},format=rgba[tx_${i}_in]`);
 
@@ -139,7 +143,7 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
             const lbl = `tx_${i}_anim${ai}`;
             f.push(`[${cur}]fade=t=in:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`);
             cur = lbl;
-          } else if (an.type === "wipe" && needBlank) {
+          } else if (an.type === "wipe" && wipeAnims.length) {
             // salta wipe oltre la durata (evita wipe-out)
             if (an.time + an.duration >= dur) return;
             const lbl = `tx_${i}_anim${ai}`;

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -134,10 +134,14 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
           if ("reversed" in an && (an as any).reversed) return; // ignora animazioni "out"
           if (an.type === "fade") {
             const st = typeof an.time === "number" ? an.time : Math.max(0, dur - an.duration);
+            // salta fade che finirebbero oltre la durata del segmento (fade-out)
+            if (st + an.duration >= dur) return;
             const lbl = `tx_${i}_anim${ai}`;
             f.push(`[${cur}]fade=t=in:st=${st}:d=${an.duration}:alpha=1,format=rgba[${lbl}]`);
             cur = lbl;
           } else if (an.type === "wipe" && needBlank) {
+            // salta wipe oltre la durata (evita wipe-out)
+            if (an.time + an.duration >= dur) return;
             const lbl = `tx_${i}_anim${ai}`;
             f.push(`[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`);
             cur = lbl;

--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -143,6 +143,8 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
             );
             cur = lbl;
           } else if (an.type === "wipe" && needBlank) {
+            // Ignore wipe-out animations for the same reason
+            if ((an as any).reversed) continue;
             const lbl = `tx_${i}_anim${ai}`;
             f.push(
               `[tx_${i}_blank][${cur}]xfade=transition=${an.direction}:duration=${an.duration}:offset=${an.time},format=rgba[${lbl}]`


### PR DESCRIPTION
## Summary
- Skip fade-out animations so text stays on screen for the full segment
- Validate asset keys and output paths to avoid creating stray files

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ea546ec883309196a1ebd2ede249