### PR TITLE
Fix TTS duration and optional background audio

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "fs";
+import { existsSync, writeFileSync } from "fs";
 import { runFFmpeg } from "./ffmpeg/run"; // ✅ percorso corretto
 
 type ConcatArgs = {
@@ -18,6 +18,8 @@ function ffSafe(p: string): string {
 export async function concatAndFinalizeDemuxer(args: ConcatArgs) {
   const { segments, bgAudioPath, outPath, concatTxtPath, fps, bgVolume = 0.15 } = args;
 
+  const hasBgAudio = !!(bgAudioPath && existsSync(bgAudioPath));
+
   // Scrivi concat.txt (una riga per file)
   const lines = segments.map((s) => `file '${ffSafe(s)}'`);
   writeFileSync(concatTxtPath, lines.join("\n"), "utf8");
@@ -30,8 +32,8 @@ export async function concatAndFinalizeDemuxer(args: ConcatArgs) {
     "-i", concatTxtPath,
   ];
 
-  if (bgAudioPath) {
-    ffargs.push("-stream_loop", "-1", "-i", bgAudioPath);
+  if (hasBgAudio) {
+    ffargs.push("-stream_loop", "-1", "-i", bgAudioPath!);
     ffargs.push(
       "-filter_complex",
       [

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1496,8 +1496,14 @@ export function buildTimelineFromLayout(
     );
 
     const ttsPath = findTTSForSlide(i);
-    let ttsDur = parseSec(mods[`TTS-${i}.duration`], 0);
-    if (!ttsDur && ttsPath) ttsDur = probeDurationSec(ttsPath);
+    const hintedTtsDur = parseSec(mods[`TTS-${i}.duration`], 0);
+    let ttsDur = hintedTtsDur;
+    if (ttsPath) {
+      const measured = probeDurationSec(ttsPath);
+      if (measured > 0) {
+        ttsDur = measured;
+      }
+    }
     if (ttsDur > slideDur) slideDur = ttsDur;
 
     const txtStr = typeof mods[`Testo-${i}`] === "string" ? mods[`Testo-${i}`].trim() : "";


### PR DESCRIPTION
## Summary
- prefer the probed duration of local TTS files so slides never truncate speech
- skip background mixing when the bg audio file is missing to let concatenation succeed

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ca82878a388330a5a20580a98ab333