### PR TITLE
Handle text alignment for outro

### DIFF
--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -75,6 +75,37 @@ test("getTextBoxFromTemplate mirrors point text margins", () => {
   assert.equal(box.h, 160);
 });
 
+test("getTextBoxFromTemplate keeps anchors beyond 100 percent", () => {
+  const tpl: TemplateDoc = {
+    width: 200,
+    height: 100,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "50%",
+            y: "80%",
+            width: "40%",
+            height: "50%",
+            x_anchor: "50%",
+            y_anchor: "150%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  assert.equal(box.x, 60);
+  assert.equal(box.y, 5);
+  assert.equal(box.w, 80);
+  assert.equal(box.h, 50);
+});
+
 test("getTextBoxFromTemplate clamps to slide bounds", () => {
   const tpl: TemplateDoc = {
     width: 100,

--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -41,8 +41,38 @@ test("getTextBoxFromTemplate uses anchors and keeps box inside canvas", () => {
   const box = getTextBoxFromTemplate(tpl, 0)!;
   assert.equal(box.x, 20);
   assert.equal(box.y, 30);
-  assert.equal(box.w, 70);
-  assert.equal(box.h, 47);
+  assert.equal(box.w, 60);
+  assert.equal(box.h, 40);
+});
+
+test("getTextBoxFromTemplate mirrors point text margins", () => {
+  const tpl: TemplateDoc = {
+    width: 400,
+    height: 200,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "25%",
+            y: "10%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "50%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  assert.equal(box.x, 100);
+  assert.equal(box.w, 200);
+  assert.equal(box.y, 20);
+  assert.equal(box.h, 160);
 });
 
 test("getTextBoxFromTemplate clamps to slide bounds", () => {
@@ -69,7 +99,7 @@ test("getTextBoxFromTemplate clamps to slide bounds", () => {
     ],
   };
   const box = getTextBoxFromTemplate(tpl, 0)!;
-  assert.equal(box.x, 77);
+  assert.equal(box.x, 80);
   assert.equal(box.y, 5);
 });
 

--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -9,6 +9,7 @@ import {
   getFontFamilyFromTemplate,
   wrapText,
   buildTimelineFromLayout,
+  APPROX_CHAR_WIDTH_RATIO,
 } from "../timeline";
 import { TEXT } from "../config";
 import type { TemplateDoc } from "../template";
@@ -70,6 +71,127 @@ test("getTextBoxFromTemplate clamps to slide bounds", () => {
   const box = getTextBoxFromTemplate(tpl, 0)!;
   assert.equal(box.x, 77);
   assert.equal(box.y, 5);
+});
+
+test("buildTimelineFromLayout aligns text horizontally inside box", () => {
+  const tpl: TemplateDoc = {
+    width: 400,
+    height: 200,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "50%",
+            y: "25%",
+            width: "50%",
+            height: "20%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "100%",
+            font_size: 40,
+            line_height: "100%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout({ "Testo-0": "CIAO" }, tpl, {
+    videoW: 400,
+    videoH: 200,
+    fps: 25,
+    defaultDur: 2,
+  });
+
+  const slide = slides[0];
+  const block = slide.texts?.[0];
+  assert.ok(block);
+  assert.ok(block?.textFile);
+  const rendered = readFileSync(block!.textFile!, "utf8");
+  const lines = rendered.split(/\r?\n/);
+  const fontPx = block!.fontSize ?? 0;
+  const textWidth = Math.max(
+    ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
+  );
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  const expected = Math.round(box.x + (box.w - textWidth));
+  assert.equal(block!.x, expected);
+});
+
+test("buildTimelineFromLayout centers outro point text", () => {
+  const tpl: TemplateDoc = {
+    width: 600,
+    height: 400,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "0%",
+            y: "0%",
+            width: "10%",
+            height: "10%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            font_size: 30,
+            line_height: "100%",
+          },
+        ],
+      },
+      {
+        type: "composition",
+        name: "Outro",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-outro",
+            x: "0%",
+            y: "0%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "50%",
+            font_size: 50,
+            line_height: "100%",
+            text: "HELLO",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout(
+    { "Testo-0": "ciao", "Testo-outro": "HELLO" },
+    tpl,
+    {
+      videoW: 600,
+      videoH: 400,
+      fps: 25,
+      defaultDur: 2,
+    }
+  );
+
+  const outro = slides[slides.length - 1];
+  const block = outro.texts?.[0];
+  assert.ok(block);
+  assert.ok(block?.textFile);
+  const rendered = readFileSync(block!.textFile!, "utf8");
+  const lines = rendered.split(/\r?\n/);
+  const fontPx = block!.fontSize ?? 0;
+  const textWidth = Math.max(
+    ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
+  );
+  const expected = Math.round((600 - textWidth) / 2);
+  assert.equal(block!.x, expected);
 });
 
 test("getLogoBoxFromTemplate uses anchors and clamps", () => {

--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -119,7 +119,8 @@ test("buildTimelineFromLayout aligns text horizontally inside box", () => {
     ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
   );
   const box = getTextBoxFromTemplate(tpl, 0)!;
-  const expected = Math.round(box.x + (box.w - textWidth));
+  const free = box.w - textWidth;
+  const expected = box.x + Math.round(Math.min(free, Math.max(0, free)));
   assert.equal(block!.x, expected);
 });
 
@@ -160,6 +161,7 @@ test("buildTimelineFromLayout centers outro point text", () => {
             x_anchor: "0%",
             y_anchor: "0%",
             x_alignment: "50%",
+            letter_spacing: "200%",
             font_size: 50,
             line_height: "100%",
             text: "HELLO",
@@ -187,10 +189,17 @@ test("buildTimelineFromLayout centers outro point text", () => {
   const rendered = readFileSync(block!.textFile!, "utf8");
   const lines = rendered.split(/\r?\n/);
   const fontPx = block!.fontSize ?? 0;
+  const letterSpacingPx = (fontPx * 200) / 1000;
   const textWidth = Math.max(
-    ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
+    ...lines.map((ln) =>
+      ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO +
+      Math.max(ln.length - 1, 0) * letterSpacingPx
+    )
   );
-  const expected = Math.round((600 - textWidth) / 2);
+  const available = 600 - textWidth;
+  const offset = Math.round(Math.max(0, available) * 0.5);
+  const clamped = Math.max(0, Math.min(Math.max(0, Math.floor(available)), offset));
+  const expected = clamped;
   assert.equal(block!.x, expected);
 });
 

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1143,7 +1143,12 @@ function parseLetterSpacing(
   if (!trimmed) return undefined;
   if (trimmed.endsWith("%")) {
     const n = parseFloat(trimmed.slice(0, -1));
-    return Number.isFinite(n) ? (n / 100) * fontPx : undefined;
+    if (!Number.isFinite(n)) return undefined;
+    // After Effects exports tracking values as percentages but they represent
+    // thousandths of an em. Convert them back to em units so "200%" -> 0.2em.
+    const normalized = n / 1000;
+    const px = normalized * fontPx;
+    return Number.isFinite(px) ? px : undefined;
   }
   const px = lenToPx(trimmed, W, H);
   if (typeof px === "number" && Number.isFinite(px)) return px;

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1004,9 +1004,10 @@ export function getTextBoxFromTemplate(
   const normAnchor = (value: number | undefined): number => {
     if (typeof value !== "number" || !Number.isFinite(value)) return 0;
     if (value <= 0) return 0;
-    if (value >= 1 && value <= 100) return value / 100;
-    if (value > 100) return 1;
-    return value;
+    if (value <= 1) return value;
+    const ratio = value / 100;
+    if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+    return ratio;
   };
 
   const xAnchor = normAnchor(pctToPx(txtEl.x_anchor, 100));


### PR DESCRIPTION
## Summary
- parse letter spacing and measure text width so horizontal alignment metadata can reposition text boxes accurately
- apply horizontal alignment adjustments for slide and outro text to keep centered point text in place without relying on artificial margins
- cover the new alignment handling with dedicated timeline tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb487f3a48330894954f1b078ad85