### PR TITLE
Expand text boxes using override content

### DIFF
--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -9,6 +9,7 @@ import {
   getFontFamilyFromTemplate,
   wrapText,
   buildTimelineFromLayout,
+  APPROX_CHAR_WIDTH_RATIO,
 } from "../timeline";
 import { TEXT } from "../config";
 import type { TemplateDoc } from "../template";
@@ -40,8 +41,108 @@ test("getTextBoxFromTemplate uses anchors and keeps box inside canvas", () => {
   const box = getTextBoxFromTemplate(tpl, 0)!;
   assert.equal(box.x, 20);
   assert.equal(box.y, 30);
-  assert.equal(box.w, 70);
-  assert.equal(box.h, 47);
+  assert.equal(box.w, 60);
+  assert.equal(box.h, 40);
+});
+
+test("getTextBoxFromTemplate mirrors point text margins", () => {
+  const tpl: TemplateDoc = {
+    width: 400,
+    height: 200,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "25%",
+            y: "10%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "50%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  assert.equal(box.x, 100);
+  assert.equal(box.w, 200);
+  assert.equal(box.y, 20);
+  assert.equal(box.h, 160);
+});
+
+test("getTextBoxFromTemplate expands zero-width boxes using override text", () => {
+  const tpl: TemplateDoc = {
+    width: 2000,
+    height: 600,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "25%",
+            y: "10%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "50%",
+            font_size: 50,
+            letter_spacing: "200%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const override = "UN TITOLO DAVVERO MOLTO LUNGO PER L'OUTRO";
+  const box = getTextBoxFromTemplate(tpl, 0, undefined, { textOverride: override })!;
+  const fontPx = 50;
+  const letterSpacingPx = (fontPx * 200) / 1000;
+  const baseWidth = override.length * fontPx * APPROX_CHAR_WIDTH_RATIO;
+  const spacing = Math.max(override.length - 1, 0) * letterSpacingPx;
+  const pad = Math.round(letterSpacingPx);
+  const expectedWidth = Math.min(2000, Math.round(baseWidth + spacing + pad));
+  assert.equal(box.w, expectedWidth);
+  const anchorX = (25 / 100) * 2000;
+  const expectedX = Math.max(0, Math.min(2000 - expectedWidth, anchorX));
+  assert.equal(box.x, expectedX);
+});
+
+test("getTextBoxFromTemplate keeps anchors beyond 100 percent", () => {
+  const tpl: TemplateDoc = {
+    width: 200,
+    height: 100,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "50%",
+            y: "80%",
+            width: "40%",
+            height: "50%",
+            x_anchor: "50%",
+            y_anchor: "150%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  assert.equal(box.x, 60);
+  assert.equal(box.y, 5);
+  assert.equal(box.w, 80);
+  assert.equal(box.h, 50);
 });
 
 test("getTextBoxFromTemplate clamps to slide bounds", () => {
@@ -68,8 +169,157 @@ test("getTextBoxFromTemplate clamps to slide bounds", () => {
     ],
   };
   const box = getTextBoxFromTemplate(tpl, 0)!;
-  assert.equal(box.x, 77);
+  assert.equal(box.x, 80);
   assert.equal(box.y, 5);
+});
+
+test("buildTimelineFromLayout aligns text horizontally inside box", () => {
+  const tpl: TemplateDoc = {
+    width: 400,
+    height: 200,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "50%",
+            y: "25%",
+            width: "50%",
+            height: "20%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "100%",
+            font_size: 40,
+            line_height: "100%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout({ "Testo-0": "CIAO" }, tpl, {
+    videoW: 400,
+    videoH: 200,
+    fps: 25,
+    defaultDur: 2,
+  });
+
+  const slide = slides[0];
+  const block = slide.texts?.[0];
+  assert.ok(block);
+  assert.ok(block?.textFile);
+  const rendered = readFileSync(block!.textFile!, "utf8");
+  const lines = rendered.split(/\r?\n/);
+  const fontPx = block!.fontSize ?? 0;
+  const textWidth = Math.max(
+    ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
+  );
+  const box = getTextBoxFromTemplate(tpl, 0)!;
+  const safeAlign = 1;
+  const anchorPoint = box.x + box.w * safeAlign;
+  const rawX = anchorPoint - textWidth * safeAlign;
+  const roundedWidth = Math.max(0, Math.round(textWidth));
+  const maxLeft = 400 - roundedWidth;
+  let expected = Math.round(rawX);
+  if (!(maxLeft >= 0)) {
+    expected = Math.max(0, expected);
+  } else {
+    if (expected < 0) expected = 0;
+    if (expected > maxLeft) expected = maxLeft;
+  }
+  assert.equal(block!.x, expected);
+});
+
+test("buildTimelineFromLayout centers outro point text", () => {
+  const tpl: TemplateDoc = {
+    width: 600,
+    height: 400,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "0%",
+            y: "0%",
+            width: "10%",
+            height: "10%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            font_size: 30,
+            line_height: "100%",
+          },
+        ],
+      },
+      {
+        type: "composition",
+        name: "Outro",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-outro",
+            x: "0%",
+            y: "0%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            x_alignment: "50%",
+            letter_spacing: "200%",
+            font_size: 50,
+            line_height: "100%",
+            text: "HELLO",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout(
+    { "Testo-0": "ciao", "Testo-outro": "HELLO" },
+    tpl,
+    {
+      videoW: 600,
+      videoH: 400,
+      fps: 25,
+      defaultDur: 2,
+    }
+  );
+
+  const outro = slides[slides.length - 1];
+  const block = outro.texts?.[0];
+  assert.ok(block);
+  assert.ok(block?.textFile);
+  const rendered = readFileSync(block!.textFile!, "utf8");
+  const lines = rendered.split(/\r?\n/);
+  const fontPx = block!.fontSize ?? 0;
+  const letterSpacingPx = (fontPx * 200) / 1000;
+  const textWidth = Math.max(
+    ...lines.map((ln) =>
+      ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO +
+      Math.max(ln.length - 1, 0) * letterSpacingPx
+    )
+  );
+  const box = getTextBoxFromTemplate(tpl, "Outro", "Testo-outro", { textOverride: "HELLO" })!;
+  const safeAlign = 0.5;
+  const anchorPoint = box.x + box.w * safeAlign;
+  const rawX = anchorPoint - textWidth * safeAlign;
+  const roundedWidth = Math.max(0, Math.round(textWidth));
+  const maxLeft = 600 - roundedWidth;
+  let expected = Math.round(rawX);
+  if (!(maxLeft >= 0)) {
+    expected = Math.max(0, expected);
+  } else {
+    if (expected < 0) expected = 0;
+    if (expected > maxLeft) expected = maxLeft;
+  }
+  assert.equal(block!.x, expected);
 });
 
 test("getLogoBoxFromTemplate uses anchors and clamps", () => {

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -7,8 +7,6 @@ import { probeDurationSec } from "./ffmpeg/probe";
 import { TEXT } from "./config";
 import { fileNameMatchesFamily } from "./fonts";
 
-const TEXT_BOX_SCALE = 70 / 60;
-
 /* ---------- Tipi usati da composition.ts ---------- */
 export type AnimationSpec =
   | {
@@ -978,7 +976,8 @@ function defaultTextBlock(x = 120, y = 160): TextBlockSpec {
 export function getTextBoxFromTemplate(
   tpl: TemplateDoc,
   slideIndexOrName: number | string,
-  textName?: string
+  textName?: string,
+  options?: { textOverride?: string }
 ): { x: number; y: number; w: number; h: number } | undefined {
   const compName =
     typeof slideIndexOrName === "number"
@@ -1000,15 +999,77 @@ export function getTextBoxFromTemplate(
 
   const rawW = pctToPx(txtEl.width, W) || 0;
   const rawH = pctToPx(txtEl.height, H) || 0;
-  const w = rawW * TEXT_BOX_SCALE;
-  const h = rawH * TEXT_BOX_SCALE;
-  const xAnchor = (pctToPx(txtEl.x_anchor, 100) || 0) / 100;
-  const yAnchor = (pctToPx(txtEl.y_anchor, 100) || 0) / 100;
+  let w = rawW;
+  let h = rawH;
+
+  const templateFont = lenToPx((txtEl as any)?.font_size, W, H);
+  const templateLetterSpacing = parseLetterSpacing(
+    (txtEl as any)?.letter_spacing,
+    templateFont,
+    W,
+    H
+  );
+  const overrideText =
+    typeof options?.textOverride === "string" ? options.textOverride : undefined;
+  const templateText = typeof (txtEl as any)?.text === "string" ? (txtEl as any).text : undefined;
+  const sampleText = overrideText && overrideText.trim() ? overrideText : templateText;
+  if (
+    !(w > 0) &&
+    sampleText &&
+    typeof templateFont === "number" &&
+    Number.isFinite(templateFont) &&
+    templateFont > 0
+  ) {
+    const sampleLines = sampleText.split(/\r?\n/);
+    const estimatedWidth = estimateTextWidth(sampleLines, templateFont, templateLetterSpacing);
+    if (estimatedWidth > 0) {
+      const pad = Math.max(
+        0,
+        Math.round(
+          templateLetterSpacing && Number.isFinite(templateLetterSpacing)
+            ? templateLetterSpacing
+            : templateFont * 0.25
+        )
+      );
+      const candidateWidth = Math.min(W, Math.round(estimatedWidth + pad));
+      if (candidateWidth > 0) {
+        w = candidateWidth;
+      }
+    }
+  }
+
+  const normAnchor = (value: number | undefined): number => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+    if (value <= 0) return 0;
+    if (value <= 1) return value;
+    const ratio = value / 100;
+    if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+    return ratio;
+  };
+
+  const xAnchor = normAnchor(pctToPx(txtEl.x_anchor, 100));
+  const yAnchor = normAnchor(pctToPx(txtEl.y_anchor, 100));
 
   const baseLeft = x - rawW * xAnchor;
   const baseTop = y - rawH * yAnchor;
-  let left = Math.max(baseLeft, x - w * xAnchor);
-  let top = Math.max(baseTop, y - h * yAnchor);
+
+  if (!(w > 0)) {
+    const mirrorLeft = Math.max(0, Math.min(W, baseLeft));
+    const mirrorWidth = W - mirrorLeft * 2;
+    if (mirrorWidth > 0) {
+      w = mirrorWidth;
+    }
+  }
+  if (!(h > 0)) {
+    const mirrorTop = Math.max(0, Math.min(H, baseTop));
+    const mirrorHeight = H - mirrorTop * 2;
+    if (mirrorHeight > 0) {
+      h = mirrorHeight;
+    }
+  }
+
+  let left = x - w * xAnchor;
+  let top = y - h * yAnchor;
 
   if (w > 0) left = Math.max(0, Math.min(W - w, left));
   else left = Math.max(0, Math.min(W - 10, left));
@@ -1077,7 +1138,7 @@ export function getFontFamilyFromTemplate(
 }
 
 const DEFAULT_CHARS_PER_LINE = 40;
-const APPROX_CHAR_WIDTH_RATIO = 0.56;
+export const APPROX_CHAR_WIDTH_RATIO = 0.56;
 const MIN_FONT_SIZE = 24;
 const MAX_FONT_LAYOUT_ITERATIONS = 6;
 
@@ -1113,6 +1174,67 @@ function maxCharsForWidth(width: number, fontSize: number): number {
   return Math.max(1, maxChars || 0);
 }
 
+function computeLineSpacingForBox(
+  font: number,
+  lineCount: number,
+  boxHeight: number | undefined,
+  lineHeightFactor: number
+): number {
+  const safeFont = Number.isFinite(font) && font > 0 ? font : MIN_FONT_SIZE;
+  const safeLines = Math.max(1, lineCount);
+  const height =
+    typeof boxHeight === "number" && Number.isFinite(boxHeight) && boxHeight > 0
+      ? boxHeight
+      : 0;
+  const lineHeightPx = height > 0 ? height / safeLines : safeFont * lineHeightFactor;
+  const targetSpacing = Math.round(safeFont * Math.max(0, lineHeightFactor - 1));
+  const availableSpacing = Math.round(Math.max(0, lineHeightPx - safeFont));
+  const spacing = Math.min(targetSpacing, availableSpacing);
+  return spacing > 0 ? spacing : 0;
+}
+
+type FontSizingInfo = { initial: number; clamp(value: number): number };
+
+function deriveFontSizing(
+  element: TemplateElement | undefined,
+  fallback: number,
+  W: number,
+  H: number
+): FontSizingInfo {
+  const fallbackFont =
+    Number.isFinite(fallback) && fallback > 0 ? fallback : MIN_FONT_SIZE;
+  const explicit = lenToPx((element as any)?.font_size, W, H);
+  const min = lenToPx((element as any)?.font_size_minimum, W, H);
+  const max = lenToPx((element as any)?.font_size_maximum, W, H);
+
+  const clamp = (value: number): number => {
+    let next = Number.isFinite(value) && value > 0 ? value : fallbackFont;
+    if (typeof max === "number" && Number.isFinite(max) && max > 0) {
+      next = Math.min(next, max);
+    }
+    if (typeof min === "number" && Number.isFinite(min) && min > 0) {
+      next = Math.max(next, min);
+    }
+    if (!(next > 0)) next = fallbackFont;
+    return Math.max(MIN_FONT_SIZE, Math.round(next));
+  };
+
+  let initial = fallbackFont;
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    initial = explicit;
+  } else {
+    if (typeof min === "number" && Number.isFinite(min) && min > 0) {
+      initial = Math.max(initial, min);
+    }
+    if (typeof max === "number" && Number.isFinite(max) && max > 0) {
+      initial = Math.min(initial, max);
+    }
+  }
+
+  initial = clamp(initial);
+  return { initial, clamp };
+}
+
 function parseLineHeightFactor(raw: any): number | undefined {
   if (typeof raw === "number" && Number.isFinite(raw)) {
     if (raw <= 0) return undefined;
@@ -1128,6 +1250,103 @@ function parseLineHeightFactor(raw: any): number | undefined {
   const n = parseFloat(trimmed);
   if (!Number.isFinite(n)) return undefined;
   return n > 10 ? n / 100 : n;
+}
+
+function parseLetterSpacing(
+  raw: any,
+  fontPx: number | undefined,
+  W: number,
+  H: number
+): number | undefined {
+  if (!(fontPx && fontPx > 0)) return undefined;
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.endsWith("%")) {
+    const n = parseFloat(trimmed.slice(0, -1));
+    if (!Number.isFinite(n)) return undefined;
+    // After Effects exports tracking values as percentages but they represent
+    // thousandths of an em. Convert them back to em units so "200%" -> 0.2em.
+    const normalized = n / 1000;
+    const px = normalized * fontPx;
+    return Number.isFinite(px) ? px : undefined;
+  }
+  const px = lenToPx(trimmed, W, H);
+  if (typeof px === "number" && Number.isFinite(px)) return px;
+  const n = parseFloat(trimmed);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function estimateLineWidth(
+  line: string,
+  fontPx: number,
+  letterSpacingPx: number | undefined
+): number {
+  if (!(fontPx > 0)) return 0;
+  const text = typeof line === "string" ? line : "";
+  const baseWidth = text.length * fontPx * APPROX_CHAR_WIDTH_RATIO;
+  if (!(baseWidth > 0)) return 0;
+  if (!(letterSpacingPx && Number.isFinite(letterSpacingPx))) return baseWidth;
+  const chars = Math.max(text.length - 1, 0);
+  const spacing = Math.max(0, chars * letterSpacingPx);
+  const total = baseWidth + spacing;
+  return total > 0 ? total : 0;
+}
+
+function estimateTextWidth(
+  lines: string[],
+  fontPx: number,
+  letterSpacingPx: number | undefined
+): number {
+  if (!Array.isArray(lines) || !lines.length) return 0;
+  let max = 0;
+  for (const line of lines) {
+    const width = estimateLineWidth(line ?? "", fontPx, letterSpacingPx);
+    if (width > max) max = width;
+  }
+  return max;
+}
+
+function applyHorizontalAlignment(
+  block: TextBlockSpec,
+  lines: string[],
+  fontPx: number | undefined,
+  letterSpacingPx: number | undefined,
+  alignX: number | undefined,
+  textBox: { x: number; w: number },
+  maxWidth: number
+): void {
+  if (!lines.length) return;
+  if (!(fontPx && fontPx > 0)) return;
+  if (alignX == null) return;
+  const safeAlign = clamp01(alignX);
+  const textWidth = estimateTextWidth(lines, fontPx, letterSpacingPx);
+  if (!(textWidth > 0)) return;
+
+  const clampWithinBounds = (value: number, contentWidth: number): number => {
+    if (!(maxWidth > 0)) return Math.max(0, Math.round(value));
+    const width = Math.max(0, Math.round(contentWidth));
+    const maxLeft = maxWidth - width;
+    const rounded = Math.round(value);
+    if (!(maxLeft >= 0)) {
+      return Math.max(0, rounded);
+    }
+    if (rounded < 0) return 0;
+    if (rounded > maxLeft) return maxLeft;
+    return rounded;
+  };
+
+  if (textBox.w > 0) {
+    const anchorPoint = textBox.x + textBox.w * safeAlign;
+    const rawX = anchorPoint - textWidth * safeAlign;
+    block.x = clampWithinBounds(rawX, textWidth);
+    return;
+  }
+
+  const anchorPoint = maxWidth * safeAlign;
+  const rawX = anchorPoint - textWidth * safeAlign;
+  block.x = clampWithinBounds(rawX, textWidth);
 }
 
 export function wrapText(text: string, maxPerLine: number): string[] {
@@ -1280,7 +1499,7 @@ function buildCopyrightBlock(
   const text = modText || tplText;
   if (!text) return undefined;
 
-  const box = getTextBoxFromTemplate(template, compName, elementName);
+  const box = getTextBoxFromTemplate(template, compName, elementName, { textOverride: text });
   if (!box) return undefined;
 
   const explicitFont = lenToPx((element as any)?.font_size, videoW, videoH);
@@ -1314,13 +1533,8 @@ function buildCopyrightBlock(
   lines = lines.map((ln) => ln.trim()).filter((ln) => ln);
   if (!lines.length) return undefined;
 
-  const computeSpacing = (font: number, lineCount: number): number => {
-    const safeLines = Math.max(1, lineCount);
-    const lineHeightPx = box.h > 0 ? box.h / safeLines : font * lineHeightFactor;
-    const targetSpacing = Math.round(font * Math.max(0, lineHeightFactor - 1));
-    const availableSpacing = Math.round(Math.max(0, lineHeightPx - font));
-    return Math.min(targetSpacing, availableSpacing);
-  };
+  const computeSpacing = (font: number, lineCount: number): number =>
+    computeLineSpacingForBox(font, lineCount, box.h, lineHeightFactor);
 
   let fontSize = clampFontSize(fontGuess);
   let spacing = computeSpacing(fontSize, lines.length);
@@ -1508,7 +1722,9 @@ export function buildTimelineFromLayout(
 
     const txtStr = typeof mods[`Testo-${i}`] === "string" ? mods[`Testo-${i}`].trim() : "";
 
-    const txtBox = getTextBoxFromTemplate(template, i) || { x: 120, y: 160, w: 0, h: 0 };
+    const txtBox =
+      getTextBoxFromTemplate(template, i, undefined, { textOverride: txtStr }) ||
+      { x: 120, y: 160, w: 0, h: 0 };
     const baseBlock = defaultTextBlock(txtBox.x, txtBox.y);
     if (txtEl) {
       const bg = parseRGBA((txtEl as any).background_color);
@@ -1545,12 +1761,21 @@ export function buildTimelineFromLayout(
       }
     }
 
-    const initialFontSize = baseBlock.fontSize ?? 60;
+    const fontSizing = deriveFontSizing(
+      txtEl as TemplateElement | undefined,
+      baseBlock.fontSize ?? MIN_FONT_SIZE,
+      videoW,
+      videoH
+    );
+    const initialFontSize = fontSizing.initial;
+    baseBlock.fontSize = initialFontSize;
     const initialMaxChars =
       txtBox.w > 0 ? maxCharsForWidth(txtBox.w, initialFontSize) : DEFAULT_CHARS_PER_LINE;
     let lines = txtStr ? wrapText(txtStr, initialMaxChars) : [];
     const lineHeightFactor =
       parseLineHeightFactor((txtEl as any)?.line_height) ?? 1.35;
+    const computeSpacing = (font: number, lineCount: number): number =>
+      computeLineSpacingForBox(font, lineCount, txtBox.h, lineHeightFactor);
 
     if (lines.length) {
       const layout = resolveTextLayout(
@@ -1561,17 +1786,36 @@ export function buildTimelineFromLayout(
       );
       if (layout) {
         lines = [...layout.lines];
-        baseBlock.fontSize = layout.font;
-        baseBlock.lineSpacing = layout.spacing;
+        const adjustedFont = fontSizing.clamp(layout.font);
+        baseBlock.fontSize = adjustedFont;
+        baseBlock.lineSpacing = computeSpacing(adjustedFont, lines.length);
+      } else {
+        const adjustedFont = fontSizing.clamp(baseBlock.fontSize ?? initialFontSize);
+        baseBlock.fontSize = adjustedFont;
+        baseBlock.lineSpacing = computeSpacing(adjustedFont, lines.length);
       }
 
-      applyExtraBackgroundPadding(
-        baseBlock,
-        baseBlock.fontSize ?? initialFontSize,
-        videoW,
-        videoH
-      );
+      const finalFont = baseBlock.fontSize ?? initialFontSize;
+      applyExtraBackgroundPadding(baseBlock, finalFont, videoW, videoH);
     }
+
+    const alignX = parseAlignmentFactor((txtEl as any)?.x_alignment);
+    const fontForAlign = baseBlock.fontSize ?? initialFontSize;
+    const letterSpacingPx = parseLetterSpacing(
+      (txtEl as any)?.letter_spacing,
+      fontForAlign,
+      videoW,
+      videoH
+    );
+    applyHorizontalAlignment(
+      baseBlock,
+      lines,
+      fontForAlign,
+      letterSpacingPx,
+      alignX,
+      txtBox,
+      videoW
+    );
 
     const alignY = parseAlignmentFactor((txtEl as any)?.y_alignment) ?? 0;
     baseBlock.y = txtBox.y;
@@ -1761,7 +2005,12 @@ export function buildTimelineFromLayout(
     );
     const logoBox = getLogoBoxFromTemplate(template, "Outro");
     const textEl = findChildByName(outroComp, "Testo-outro") as any;
-    const textBox = getTextBoxFromTemplate(template, "Outro", "Testo-outro");
+    const outroModTextRaw = mods["Testo-outro"];
+    const outroModText =
+      typeof outroModTextRaw === "string" ? outroModTextRaw.trim() : undefined;
+    const textBox = getTextBoxFromTemplate(template, "Outro", "Testo-outro", {
+      textOverride: outroModText,
+    });
     const fontFam = getFontFamilyFromTemplate(template, "Outro", "Testo-outro");
     const fontPath = fontFam ? findFontPath(fontFam) : undefined;
     const outroBgNames = outroBackgroundNameCandidates();
@@ -1774,7 +2023,8 @@ export function buildTimelineFromLayout(
       ),
     ];
     const outroHasShadow = outroShadowSources.some((get) => !!get());
-    const txt = textEl?.text as string | undefined;
+    const tplOutroText = typeof textEl?.text === "string" ? (textEl.text as string) : undefined;
+    const txt = outroModText && outroModText.length ? outroModText : tplOutroText;
     let texts: TextBlockSpec[] | undefined;
     if (txt && textBox) {
       const baseOut = defaultTextBlock(textBox.x, textBox.y);
@@ -1806,12 +2056,21 @@ export function buildTimelineFromLayout(
           baseOut.boxAlpha = bg.alpha;
         }
       }
-      const initialOutSize = baseOut.fontSize ?? 60;
+      const fontSizing = deriveFontSizing(
+        textEl as TemplateElement | undefined,
+        baseOut.fontSize ?? MIN_FONT_SIZE,
+        videoW,
+        videoH
+      );
+      const initialOutSize = fontSizing.initial;
+      baseOut.fontSize = initialOutSize;
       const initialOutMax =
         textBox.w > 0 ? maxCharsForWidth(textBox.w, initialOutSize) : DEFAULT_CHARS_PER_LINE;
       let linesOut = wrapText(txt, initialOutMax);
       const lineHeightFactorOut =
         parseLineHeightFactor(textEl?.line_height) ?? 1.35;
+      const computeSpacingOut = (font: number, lineCount: number): number =>
+        computeLineSpacingForBox(font, lineCount, textBox.h, lineHeightFactorOut);
 
       if (linesOut.length) {
         const layout = resolveTextLayout(
@@ -1822,17 +2081,36 @@ export function buildTimelineFromLayout(
         );
         if (layout) {
           linesOut = [...layout.lines];
-          baseOut.fontSize = layout.font;
-          baseOut.lineSpacing = layout.spacing;
+          const adjustedFont = fontSizing.clamp(layout.font);
+          baseOut.fontSize = adjustedFont;
+          baseOut.lineSpacing = computeSpacingOut(adjustedFont, linesOut.length);
+        } else {
+          const adjustedFont = fontSizing.clamp(baseOut.fontSize ?? initialOutSize);
+          baseOut.fontSize = adjustedFont;
+          baseOut.lineSpacing = computeSpacingOut(adjustedFont, linesOut.length);
         }
 
-        applyExtraBackgroundPadding(
-          baseOut,
-          baseOut.fontSize ?? initialOutSize,
-          videoW,
-          videoH
-        );
+        const finalFont = baseOut.fontSize ?? initialOutSize;
+        applyExtraBackgroundPadding(baseOut, finalFont, videoW, videoH);
       }
+
+      const alignX = parseAlignmentFactor(textEl?.x_alignment);
+      const fontForAlign = baseOut.fontSize ?? initialOutSize;
+      const letterSpacingPx = parseLetterSpacing(
+        textEl?.letter_spacing,
+        fontForAlign,
+        videoW,
+        videoH
+      );
+      applyHorizontalAlignment(
+        baseOut,
+        linesOut,
+        fontForAlign,
+        letterSpacingPx,
+        alignX,
+        textBox,
+        videoW
+      );
 
       const alignY = parseAlignmentFactor(textEl?.y_alignment) ?? 0;
       baseOut.y = textBox.y;


### PR DESCRIPTION
## Summary
- expand `getTextBoxFromTemplate` to compute zero-width boxes from override text and keep anchors clamped inside the canvas
- update slide, outro, and copyright builders to pass override strings and realign text using axis-based positioning
- add regression coverage for override-driven sizing and refresh horizontal alignment expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb487f3a48330894954f1b078ad85