### PR TITLE
Enforce minimum width on parsed text boxes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export const TEXT = {
   CHAR_WIDTH_K: 0.55, // 0.52–0.58 a seconda del font
   /** padding extra per gli sfondi del testo (in multipli del font size) */
   BOX_PAD_FACTOR: 0.30,
+  /** larghezza minima del box testo (percentuale della larghezza video) */
+  MIN_BOX_WIDTH_RATIO: 0.75,
 };
 
 /** Scale di base (fontsize ≈ scale * videoH) */


### PR DESCRIPTION
## Summary
- expand parsed template text boxes to at least the configured minimum width so slide text has the expected wrapping room
- refresh textbox geometry assertions and widen the wipe regression input to reflect the larger backgrounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce89d5b824833098fec490a495487a