### PR TITLE
Handle filler backgrounds and outro shapes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export const TEXT = {
 
   MAX_CHARS_PER_LINE: 30,
   /** fattore massimo di scala per i font ricavati dal template quando il box si allarga */
-  MAX_FONT_SCALE: 1,
+  MAX_FONT_SCALE: 2,
   /** padding extra per gli sfondi del testo (in multipli del font size) */
   BOX_PAD_FACTOR: 0.30,
   /** larghezza minima del box testo (percentuale della larghezza video) */


### PR DESCRIPTION
## Summary
- allow extracting full-frame shapes from compositions and fall back to composition fill colors when no layered shapes are available
- include those background shapes for slides without a downloaded background image and for the outro composition so filler slides and outro inherit template colors
- raise `TEXT.MAX_FONT_SCALE` to 2 so template fonts can expand when their boxes widen, matching the expected layout scaling

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d04cca05d08330ad9cc6b37ce35493