### PR TITLE
Respect template alignment, colors, and logo positions

### DIFF
--- a/src/tests/timeline/slidesFlow.test.ts
+++ b/src/tests/timeline/slidesFlow.test.ts
@@ -65,6 +65,64 @@ test("buildTimelineFromLayout includes filler slide and outro", () => {
   assert.equal(slides[3].durationSec, 1);
 });
 
+test("buildTimelineFromLayout reuses template logo position for gap filler", () => {
+  const tpl: TemplateDoc = {
+    width: 800,
+    height: 600,
+    elements: [
+      { type: "composition", name: "Slide_0", duration: 1, elements: [] },
+      {
+        type: "composition",
+        name: "Slide_1",
+        duration: 1,
+        elements: [
+          {
+            type: "image",
+            name: "Logo",
+            x: "60%",
+            y: "70%",
+            width: "10%",
+            height: "15%",
+            x_anchor: "50%",
+            y_anchor: "50%",
+          },
+          { type: "text", name: "Testo-1", x: "0%", y: "0%", width: "10%", height: "10%", x_anchor: "0%", y_anchor: "0%" },
+        ],
+      },
+    ],
+  } as any;
+
+  const mods = {
+    "Slide_0.time": "0 s",
+    "Slide_1.time": "5 s",
+    "Testo-1": "ciao",
+  };
+
+  const prevImages = paths.images;
+  const prevTts = paths.tts;
+  paths.images = "/tmp/no_img";
+  paths.tts = "/tmp/no_tts";
+
+  try {
+    const slides = buildTimelineFromLayout(mods, tpl, {
+      videoW: 800,
+      videoH: 600,
+      fps: 30,
+      defaultDur: 1,
+    });
+
+    assert.equal(slides.length, 3);
+    const filler = slides[1];
+    assert.equal(filler.logoWidth, 80);
+    assert.equal(filler.logoHeight, 90);
+    assert.equal(filler.logoX, 440);
+    assert.equal(filler.logoY, 375);
+  } finally {
+    paths.images = prevImages;
+    paths.tts = prevTts;
+  }
+});
+
 test("buildTimelineFromLayout inserts gap filler and extends to TTS length", () => {
   const tpl: TemplateDoc = {
     width: 100,

--- a/src/tests/timeline/textLayout.test.ts
+++ b/src/tests/timeline/textLayout.test.ts
@@ -68,6 +68,103 @@ test("buildTimelineFromLayout aligns text horizontally inside box", () => {
   assert.equal(block!.x, expected);
 });
 
+test("buildTimelineFromLayout honors text_align keywords", () => {
+  const tpl: TemplateDoc = {
+    width: 400,
+    height: 200,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "25%",
+            y: "30%",
+            width: "50%",
+            height: "20%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            text_align: "center",
+            font_size: 36,
+            line_height: "100%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout({ "Testo-0": "NOTIZIA" }, tpl, {
+    videoW: 400,
+    videoH: 200,
+    fps: 25,
+    defaultDur: 2,
+  });
+
+  const slide = slides[0];
+  const block = slide.texts?.[0];
+  assert.ok(block);
+  assert.ok(block?.textFile);
+  const rendered = readFileSync(block!.textFile!, "utf8");
+  const lines = rendered.split(/\r?\n/);
+  const fontPx = block!.fontSize ?? 0;
+  const textWidth = Math.max(
+    ...lines.map((ln) => ln.length * fontPx * APPROX_CHAR_WIDTH_RATIO)
+  );
+  const box = getTextBoxFromTemplate(tpl, 0, undefined, {
+    preserveOrigin: true,
+    minWidthRatio: TEXT.MIN_BOX_WIDTH_RATIO,
+  })!;
+
+  const free = box.w - textWidth;
+  const expected = box.x + Math.round(Math.min(free, Math.max(0, free * 0.5)));
+  assert.equal(block!.x, expected);
+});
+
+test("buildTimelineFromLayout applies template text color", () => {
+  const tpl: TemplateDoc = {
+    width: 640,
+    height: 360,
+    elements: [
+      {
+        type: "composition",
+        name: "Slide_0",
+        duration: 2,
+        elements: [
+          {
+            type: "text",
+            name: "Testo-0",
+            x: "10%",
+            y: "20%",
+            width: "60%",
+            height: "30%",
+            x_anchor: "0%",
+            y_anchor: "0%",
+            fill_color: "rgba(18, 52, 86, 0.5)",
+            font_size: 40,
+            line_height: "120%",
+          },
+        ],
+      },
+    ],
+  } as any;
+
+  const slides = buildTimelineFromLayout({ "Testo-0": "COLORE" }, tpl, {
+    videoW: 640,
+    videoH: 360,
+    fps: 25,
+    defaultDur: 2,
+  });
+
+  const slide = slides[0];
+  assert.ok(slide);
+  const block = slide.texts?.[0];
+  assert.ok(block);
+  assert.equal(block!.fontColor, "#123456@0.5");
+});
+
 test("buildTimelineFromLayout scales template font with widened boxes", () => {
   const tpl: TemplateDoc = {
     width: 800,

--- a/src/timeline/builders/gapSlide.ts
+++ b/src/timeline/builders/gapSlide.ts
@@ -15,11 +15,17 @@ export function createGapSlide(
   durationSec: number
 ): SlideSpec {
   const logoBox = getLogoBoxFromTemplate(template, target);
-  const fallback = { x: Math.round((videoW - 240) / 2), y: Math.round((videoH - 140) / 2), w: 240, h: 140 };
-  const width = Math.max(logoBox.w ?? fallback.w, 1);
-  const height = Math.max(logoBox.h ?? fallback.h, 1);
-  const x = Math.round((videoW - width) / 2);
-  const y = Math.round((videoH - height) / 2);
+  const fallback = { w: 240, h: 140 };
+  const width = Math.max(1, Math.min(videoW, logoBox.w ?? fallback.w));
+  const height = Math.max(1, Math.min(videoH, logoBox.h ?? fallback.h));
+  const centerX = Math.round((videoW - width) / 2);
+  const centerY = Math.round((videoH - height) / 2);
+  const maxX = Math.max(0, videoW - width);
+  const maxY = Math.max(0, videoH - height);
+  const rawX = typeof logoBox.x === "number" ? logoBox.x : centerX;
+  const rawY = typeof logoBox.y === "number" ? logoBox.y : centerY;
+  const x = Math.max(0, Math.min(maxX, Math.round(rawX)));
+  const y = Math.max(0, Math.min(maxY, Math.round(rawY)));
 
   return {
     width: videoW,

--- a/src/timeline/text.ts
+++ b/src/timeline/text.ts
@@ -215,6 +215,12 @@ export function parseAlignmentFactor(raw: unknown): number | undefined {
   if (typeof raw !== "string") return undefined;
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
+
+  const keyword = trimmed.toLowerCase();
+  if (keyword === "left" || keyword === "start") return 0;
+  if (keyword === "center" || keyword === "centre" || keyword === "middle") return 0.5;
+  if (keyword === "right" || keyword === "end") return 1;
+
   if (trimmed.endsWith("%")) {
     const parsed = parseFloat(trimmed.slice(0, -1));
     return Number.isFinite(parsed) ? clamp01(parsed / 100) : undefined;


### PR DESCRIPTION
## Summary
- normalize template-provided text colors, including rgba and keyword-based alignment hints, when building slide text blocks
- clamp logo gap slides to the coordinates defined in the template and support alignment keywords in the text engine
- extend timeline tests to cover text alignment keywords, text color extraction, and gap filler logo placement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0c8527bcc8330a373df56fefa227c