### PR TITLE
Handle camelCase text alignment properties

### DIFF
--- a/src/timeline/builders/textBlocks.ts
+++ b/src/timeline/builders/textBlocks.ts
@@ -8,6 +8,7 @@ import {
   parseAlignmentFactor,
   parseLetterSpacing,
   parseLineHeightFactor,
+  resolveHorizontalAlignmentSource,
   resolveTextLayout,
   wrapText,
   fitTextWithTargetFont,
@@ -301,13 +302,7 @@ export function buildTextBlocks(params: BuildTextBlocksParams): BuildTextBlocksR
   const finalFont = block.fontSize ?? initialFontSize;
   applyExtraBackgroundPadding(block, finalFont, videoW, videoH);
 
-  const alignSource =
-    templateProps?.x_alignment ??
-    templateProps?.text_align ??
-    templateProps?.text_alignment ??
-    templateProps?.horizontal_alignment ??
-    templateProps?.align ??
-    templateProps?.alignment;
+  const alignSource = resolveHorizontalAlignmentSource(templateProps);
   const alignX = defaultAlignX ?? parseAlignmentFactor(alignSource);
   const letterSpacingPx = parseLetterSpacing(
     templateProps?.letter_spacing,

--- a/src/timeline/templateHelpers.ts
+++ b/src/timeline/templateHelpers.ts
@@ -15,6 +15,7 @@ import {
   parseAlignmentFactor,
   parseLetterSpacing,
   parseLineHeightFactor,
+  resolveHorizontalAlignmentSource,
   resolveTextLayout,
   wrapText,
 } from "./text";
@@ -364,13 +365,7 @@ export function buildCopyrightBlock(
     lineSpacing: spacing,
   };
 
-  const alignSource =
-    (element as any)?.x_alignment ??
-    (element as any)?.text_align ??
-    (element as any)?.text_alignment ??
-    (element as any)?.horizontal_alignment ??
-    (element as any)?.align ??
-    (element as any)?.alignment;
+  const alignSource = resolveHorizontalAlignmentSource(element);
   const alignX = parseAlignmentFactor(alignSource);
   if (alignX != null) {
     const letterSpacingPx = parseLetterSpacing(

--- a/src/timeline/text.ts
+++ b/src/timeline/text.ts
@@ -231,6 +231,29 @@ export function parseAlignmentFactor(raw: unknown): number | undefined {
   return clamp01(parsed > 1 ? parsed / 100 : parsed);
 }
 
+export function resolveHorizontalAlignmentSource(element: unknown): unknown {
+  if (!element || typeof element !== "object") return undefined;
+  const props = element as Record<string, unknown>;
+  const candidates = [
+    props?.x_alignment,
+    props?.text_align,
+    props?.text_alignment,
+    props?.horizontal_alignment,
+    props?.align,
+    props?.alignment,
+    props?.xAlignment,
+    props?.textAlign,
+    props?.textAlignment,
+    props?.horizontalAlignment,
+    props?.xAlign,
+    props?.horizontalAlign,
+  ];
+  for (const candidate of candidates) {
+    if (candidate != null) return candidate;
+  }
+  return undefined;
+}
+
 export function estimateLineWidth(
   line: string,
   fontPx: number,


### PR DESCRIPTION
## Summary
- allow text alignment parsing to read both snake_case and camelCase properties
- reuse the new helper when building text blocks and template helper alignment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0e2971d688330a94dde654984aee9