### PR TITLE
Adjust background zoom timing

### DIFF
--- a/src/renderers/composition.ts
+++ b/src/renderers/composition.ts
@@ -66,7 +66,7 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
   if (hasBG) {
     if (animateBackground && dur > 0) {
       const animFps = fps > 0 ? fps : 30;
-      const targetZoom = 1.34;
+      const targetZoom = 1.48;
       const targetZoomExpr = targetZoom.toFixed(6);
       const durExpr = dur.toFixed(6);
       const totalFrames = Math.max(Math.round(dur * animFps), 1);
@@ -82,7 +82,7 @@ export async function renderSlideSegment(slide: SlideSpec): Promise<void> {
         const baseZoomProgressExpr = `(min(on\,${framesMinusOne})/${framesMinusOneExpr})`;
         // Cubic ease-out for an even quicker acceleration than the previous quadratic curve.
         const cubicEaseOutExpr = `1-pow(1-${baseZoomProgressExpr},3)`;
-        const lingerEaseExpr = `pow(${cubicEaseOutExpr},1.12)`;
+        const lingerEaseExpr = `pow(${cubicEaseOutExpr},1.2)`;
         const zoomSpeedMultiplier = 1.22;
         const zoomProgressExpr = `min(${zoomSpeedMultiplier.toFixed(6)}*${lingerEaseExpr},1)`;
         const zoomExpr = `1+(${targetZoomExpr}-1)*${zoomProgressExpr}`;


### PR DESCRIPTION
## Summary
- increase the background zoom target to create a snappier push-in during animated slides
- steepen the lingering ease curve so the movement continues slightly closer to the end of the shot

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d118bf58308330b92567b75dd339c5