### PR TITLE
Increase overlap between text line wipes

### DIFF
--- a/src/tests/timeline/shapesAndAnimations.test.ts
+++ b/src/tests/timeline/shapesAndAnimations.test.ts
@@ -388,6 +388,6 @@ test("buildTimelineFromLayout uses fixed wipe timings", () => {
     { type: "wipe", time: 0, duration: 0.8, direction: "wipeleft" },
   ]);
   assert.deepEqual(t0[1].animations, [
-    { type: "wipe", time: 0.6, duration: 0.8, direction: "wipeleft" },
+    { type: "wipe", time: 0.4, duration: 0.8, direction: "wipeleft" },
   ]);
 });

--- a/src/timeline/constants.ts
+++ b/src/timeline/constants.ts
@@ -1,5 +1,5 @@
 export const LINE_WIPE_DURATION = 0.8;
-export const LINE_WIPE_OVERLAP = 0.2;
+export const LINE_WIPE_OVERLAP = 0.4;
 export const DEFAULT_CHARS_PER_LINE = 40;
 export const MIN_FONT_SIZE = 24;
 export const APPROX_CHAR_WIDTH_RATIO = 0.56;


### PR DESCRIPTION
## Summary
- increase the default overlap used when staggering text line wipe/fade animations so the next line starts appearing earlier
- update the fixed timing test to reflect the new overlap

## Testing
- `npm test` *(fails: existing text box/layout assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ff7e7004833098e53f4fef721e32